### PR TITLE
Cloud Run Jobのタイムアウトの変更

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -56,7 +56,7 @@ flowchart TD
   - `DISCORD_WEBHOOK_INFO_URL` / `DISCORD_WEBHOOK_ERROR_URL` = Secret Manager から取得した値
   - `TRIGGER_FILE` = Workflows から渡されるオブジェクト名
 - 設定値 (root `job.tf`):
-  - timeout: `540s`
+  - timeout: `3600s`
   - memory: `8Gi`
   - cpu: `2`
   - max instances: `1`

--- a/infrastructure/job.tf
+++ b/infrastructure/job.tf
@@ -12,7 +12,7 @@ module "cloud_run_job" {
   job_name                       = "${var.system}-app-${var.environment}"
   service_account_email          = local.default_compute_service_account
 
-  timeout            = "540s"
+  timeout            = "3600s"
   memory             = "8Gi"
   cpu                = "2"
   max_instance_count = 1


### PR DESCRIPTION
## 変更点
<!-- 箇条書きで具体的に -->
- Cloud Run Jobのタイムアウトを540秒から3600秒に延長

## 関連Issue
<!-- 例: Fixes #123 / Fixes #123, #456 -->
- Fixes #31 

## テスト
<!-- 実施したテストと結果を記載 -->
-

## 補足・備考
<!-- リスク、ロールバック、影響範囲、スクリーンショット等 -->
> 専用SAが作成され、Vertex AI/Storage等の権限が付与されている。

専用SAではなくデフォルトSAを使用して、すでに権限付与済み
- https://github.com/sunaba-log/podcast-automator/blob/7ea9ad262dadf1f00ed1cde1d89345884a9eabf6/infrastructure/iam.tf#L1-L7
- https://github.com/sunaba-log/podcast-automator/blob/7ea9ad262dadf1f00ed1cde1d89345884a9eabf6/infrastructure/iam.tf#L17-L23

>  GCSにファイルを置いてトリガーが発火する。

対応済み
- https://github.com/sunaba-log/podcast-automator/blob/7ea9ad262dadf1f00ed1cde1d89345884a9eabf6/infrastructure/eventarc.tf#L6-L18
