### PR TITLE
feat(iam): grant Secret Manager access to job service account

### DIFF
--- a/infrastructure/iam.tf
+++ b/infrastructure/iam.tf
@@ -62,6 +62,14 @@ resource "google_project_iam_member" "job_run_admin" {
   depends_on = [google_project_service.required]
 }
 
+resource "google_project_iam_member" "job_secret_accessor" {
+  project = var.project_id
+  role    = "roles/secretmanager.secretAccessor"
+  member  = "serviceAccount:${local.default_compute_service_account}"
+
+  depends_on = [google_project_service.required]
+}
+
 resource "google_project_iam_member" "eventarc_service_agent" {
   project = var.project_id
   role    = "roles/eventarc.serviceAgent"


### PR DESCRIPTION
## 変更点
- ジョブ用サービスアカウント（default compute SA）に Secret Manager の `secretAccessor` 権限を付与
- 依存関係は既存の `google_project_service.required` に合わせて統一

## 関連Issue
- Fixes #44

## テスト
- 未実施（IAM 設定のみ）

## 補足・備考
- 変更ファイル: `infrastructure/iam.tf`
