### PR TITLE
編集可能なメタデータの追加、関数の修正

### DIFF
--- a/app/src/services/rss_manager.py
+++ b/app/src/services/rss_manager.py
@@ -643,12 +643,12 @@ class PodcastRssManager:
         category: str,
         cover_url: str,
         owner_name: str,
-        owner_email: str = "",
+        owner_email: str = "admin@sunabalog.com",
         author: str = "",
         copyright_text: str = "",
-        show_link: str = "",
+        show_link: str = "https://sunabalog.com",
         podcast_type: str = "episodic",
-        rss_link: str = "",
+        rss_link: str = "https://podcast.sunabalog.com/feed.xml",
     ) -> str:
         """新しいポッドキャストRSSフィードを生成.
 
@@ -683,12 +683,12 @@ class PodcastRssManager:
             # ウェブサイトのHTML版へのリンク(alternate)
             self.fg.link(href=show_link, rel="alternate", type="text/html")
         # rss_linkが指定されていればatom:linkも設定
-        if rss_link != "":
-            self.fg.id(rss_link)  # フィードの一意なID
-            # Atomフィード自体へのリンク(self)
-            self.fg.link(href=rss_link, rel="self", type="application/rss+xml")
-            # フィードをファイルに出力
-            # self.fg.atom_file("atom.xml")
+        # if rss_link != "":
+        self.fg.id(rss_link)  # フィードの一意なID
+        # Atomフィード自体へのリンク(self)
+        self.fg.link(href=rss_link, rel="self", type="application/rss+xml")
+        # フィードをファイルに出力
+        # self.fg.atom_file("atom.xml")
         self.fg.description(description)  # 番組説明
         self.fg.language(language)
 

--- a/app/tests/test_rss_manager_metadata.py
+++ b/app/tests/test_rss_manager_metadata.py
@@ -48,6 +48,7 @@ class TestXMLEscaping:
         )
 
         episode_data = {
+            "link": "https://example.com/episode1",
             "title": "Episode 1 & Tutorial: HTML < CSS > JavaScript",
             "description": 'Learn about "HTML" & <CSS>. Don\'t skip!',
             "audio_url": "https://example.com/audio.mp3",


### PR DESCRIPTION
## 変更点

This pull request updates the RSS feed management logic to improve iTunes compatibility, enhance episode and channel metadata handling, and introduce new methods for updating channel information. The most significant changes include support for the "clean" value in iTunes explicit fields, stricter extraction and validation of owner information, and the addition of channel update functionality.

**iTunes metadata improvements:**

* The `itunes_explicit` field for both channel and episode data now supports "yes", "no", and "clean" values, aligning with iTunes specifications. [[1]](diffhunk://#diff-4d7a253afed503f76343fa5327a5eb8980a065fec70b91408777a1d1efd7ccfdL30-R30) [[2]](diffhunk://#diff-4d7a253afed503f76343fa5327a5eb8980a065fec70b91408777a1d1efd7ccfdL69-R69) [[3]](diffhunk://#diff-4d7a253afed503f76343fa5327a5eb8980a065fec70b91408777a1d1efd7ccfdL517-R544) [[4]](diffhunk://#diff-4d7a253afed503f76343fa5327a5eb8980a065fec70b91408777a1d1efd7ccfdL537-R578)
* The extraction logic for owner information now pulls from `publisher_detail` or `author_detail` and enforces that both name and email must be present, raising an error otherwise. [[1]](diffhunk://#diff-4d7a253afed503f76343fa5327a5eb8980a065fec70b91408777a1d1efd7ccfdR335-R340) [[2]](diffhunk://#diff-4d7a253afed503f76343fa5327a5eb8980a065fec70b91408777a1d1efd7ccfdL349-R356)

**RSS feed and episode handling:**

* The RSS feed's self-link type was changed from `application/atom+xml` to `application/rss+xml` for better compatibility, and redundant atom file logic was removed. [[1]](diffhunk://#diff-4d7a253afed503f76343fa5327a5eb8980a065fec70b91408777a1d1efd7ccfdL237-R240) [[2]](diffhunk://#diff-4d7a253afed503f76343fa5327a5eb8980a065fec70b91408777a1d1efd7ccfdL654-L658)
* Episode extraction now captures additional iTunes fields, including season, episode number, explicit status, and image, with improved assignment logic. [[1]](diffhunk://#diff-4d7a253afed503f76343fa5327a5eb8980a065fec70b91408777a1d1efd7ccfdL404-R415) [[2]](diffhunk://#diff-4d7a253afed503f76343fa5327a5eb8980a065fec70b91408777a1d1efd7ccfdL425-R443)

**API and method enhancements:**

* Added a `update_channel` method to update channel metadata and regenerate the RSS XML, supporting all keys defined in `ChannelData`.
* The `get_latest_episode` method now returns the most recent episode based on publication date, and a new `list_episodes` method provides access to all episodes.

**CDATA handling and documentation:**

* The set of RSS tags wrapped in CDATA was streamlined, and documentation for episode and channel update methods was expanded and clarified. [[1]](diffhunk://#diff-4d7a253afed503f76343fa5327a5eb8980a065fec70b91408777a1d1efd7ccfdL486-R513) [[2]](diffhunk://#diff-4d7a253afed503f76343fa5327a5eb8980a065fec70b91408777a1d1efd7ccfdL706-R739) [[3]](diffhunk://#diff-4d7a253afed503f76343fa5327a5eb8980a065fec70b91408777a1d1efd7ccfdL537-R578)

**Function signature updates:**

* The `generate_podcast_rss` function now requires `rss_link` as a parameter, reflecting the new handling of feed links.

Let me know if you want to discuss any specific part of these changes in more detail!
