### PR TITLE
80-<description>はCDATAで囲うがHTMLタグの<p>,<br>で記載する。一方でitunes:summary内ではCDATAに囲わずHTMLタグをXML形式にスケープするよう変更

### DIFF
--- a/app/examples/example_description_itunes_summary.py
+++ b/app/examples/example_description_itunes_summary.py
@@ -1,0 +1,79 @@
+"""descriptionとitunes:summaryの処理例を示すスクリプト."""
+
+import sys
+from pathlib import Path
+
+# src ディレクトリをパスに追加
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+from services import PodcastRssManager
+
+
+def main():
+    """RSSフィードを生成してdescriptionとitunes:summaryの処理を確認."""
+    # RSSマネージャーを初期化
+    rss_manager = PodcastRssManager()
+
+    # ポッドキャストを生成
+    rss_manager.generate_podcast_rss(
+        title="テストポッドキャスト",
+        description="これはテストポッドキャストです",
+        language="ja",
+        category="Technology",
+        cover_url="https://example.com/cover.jpg",
+        owner_name="テストオーナー",
+    )
+
+    # HTMLタグを含むエピソードを追加
+    html_content = """<p>このエピソードではHTML & XMLの違いについて説明します。</p>
+<br>
+<p>重要なポイント:</p>
+<ul>
+<li>HTML < XML</li>
+<li>特殊文字 & エスケープ</li>
+</ul>"""
+
+    episode_data = {
+        "title": "Episode 1: HTML & XML入門",
+        "description": html_content,
+        "itunes_summary": html_content,
+        "audio_url": "https://example.com/episode1.mp3",
+        "itunes_duration": "00:30:00",
+        "file_size": 15000000,
+    }
+
+    rss_manager.add_episode(episode_data)
+
+    # 生成されたRSS XMLを取得
+    rss_xml = rss_manager.get_rss_xml()
+
+    # 結果を表示
+    print("=" * 80)
+    print("生成されたRSS XML:")
+    print("=" * 80)
+    print(rss_xml)
+    print("\n" + "=" * 80)
+    print("検証結果:")
+    print("=" * 80)
+
+    # descriptionの確認
+    if "<description><![CDATA[" in rss_xml and "<p>このエピソードでは" in rss_xml:
+        print("✓ <description>はCDATAで囲まれ、HTMLタグがそのまま維持されています")
+    else:
+        print("✗ <description>の処理に問題があります")
+
+    # itunes:summaryの確認
+    if "&lt;p&gt;" in rss_xml and "&lt;ul&gt;" in rss_xml:
+        print("✓ <itunes:summary>内のHTMLタグはXMLエスケープされています")
+    else:
+        print("✗ <itunes:summary>の処理に問題があります")
+
+    # CDATA確認
+    if "<itunes:summary><![CDATA[" not in rss_xml:
+        print("✓ <itunes:summary>はCDATAで囲まれていません")
+    else:
+        print("✗ <itunes:summary>がCDATAで囲まれています（不正）")
+
+
+if __name__ == "__main__":
+    main()

--- a/app/src/services/ai_analyzer.py
+++ b/app/src/services/ai_analyzer.py
@@ -156,7 +156,7 @@ class AudioAnalyzer:
 出力は必ず **JSONのみ** とし、次のスキーマに厳密に従ってください。
 {{
     "title": "キャッチーで分かりやすいエピソードタイトル(200文字以内)",
-    "description": "RSSフィードに適したHTMLタグを**エスケープした**番組紹介文。**生のHTMLタグは使用せず**、&amp;lt; &amp;gt; &amp;amp; で必ずエスケープしてください。段落は&amp;lt;p&amp;gt;...&amp;lt;/p&amp;gt;、強調見出しは&amp;lt;strong&amp;gt;...&amp;lt;/strong&amp;gt;、空行は&amp;lt;p&amp;gt;&amp;lt;br /&amp;gt;&amp;lt;/p&amp;gt;で表現してください。"
+    "description": "RSSフィードに適した番組紹介文。HTMLタグは<p>と<br>のみを使用してください。段落は<p>...</p>で囲み、改行は<br>を使用してください。その他のHTMLタグは使用しないでください。"
 }}
 
 制約条件:
@@ -167,9 +167,11 @@ class AudioAnalyzer:
     技術スタックとキーワードは**箇条書き**で列挙すること
     キーワード: 議事録内で扱われたキーワードを**箇条書き**で列挙
   4. about us
+- HTMLタグは<p>と<br>のみを使用すること
+- 見出しは【】で囲んでテキストとして表現すること
 
 descriptionの出力例:
-&amp;lt;p&amp;gt;&amp;lt;strong&amp;gt;【エピソード概要】&amp;lt;/strong&amp;gt; &amp;lt;/p&amp;gt;&amp;lt;p&amp;gt;&amp;lt;br /&amp;gt;&amp;lt;/p&amp;gt;&amp;lt;p&amp;gt;&amp;lt;strong&amp;gt;【目次】&amp;lt;/strong&amp;gt; &amp;lt;/p&amp;gt;&amp;lt;p&amp;gt;0:00 AAA&amp;lt;/p&amp;gt;&amp;lt;p&amp;gt;0:16 BBB&amp;lt;/p&amp;gt;&amp;lt;p&amp;gt;&amp;lt;br /&amp;gt;&amp;lt;/p&amp;gt;&amp;lt;p&amp;gt;&amp;lt;strong&amp;gt;【関連情報】&amp;lt;/strong&amp;gt; &amp;lt;/p&amp;gt;&amp;lt;p&amp;gt;- GitHub: https://github.com/sunaba-log&amp;lt;/p&amp;gt;&amp;lt;p&amp;gt;- 技術スタック: 議事録内で扱われた技術スタックを**箇条書き**で列挙&amp;lt;/p&amp;gt;&amp;lt;p&amp;gt;  - 例: GCS&amp;lt;/p&amp;gt;&amp;lt;p&amp;gt;- キーワード: 議事録内で扱われたキーワードを**箇条書き**で列挙&amp;lt;/p&amp;gt;&amp;lt;p&amp;gt;  - 例: ARグラス&amp;lt;/p&amp;gt;&amp;lt;p&amp;gt;&amp;lt;br /&amp;gt;&amp;lt;/p&amp;gt;&amp;lt;p&amp;gt;&amp;lt;strong&amp;gt;【about us】&amp;lt;/strong&amp;gt;&amp;lt;/p&amp;gt;&amp;lt;p&amp;gt;sunaba log: 友人同士で週次で雑談しながら「30 days to build」プロジェクトを進行する、雑談発想型プロトタイピング会議録。&amp;lt;/p&amp;gt;
+<p>【エピソード概要】</p><p><br></p><p>【目次】</p><p>0:00 AAA</p><p>0:16 BBB</p><p><br></p><p>【関連情報】</p><p>- GitHub: https://github.com/sunaba-log</p><p>- 技術スタック: 議事録内で扱われた技術スタックを箇条書きで列挙</p><p>  - 例: GCS</p><p>- キーワード: 議事録内で扱われたキーワードを箇条書きで列挙</p><p>  - 例: ARグラス</p><p><br></p><p>【about us】</p><p>sunaba log: 友人同士で週次で雑談しながら「30 days to build」プロジェクトを進行する、雑談発想型プロトタイピング会議録。</p>
 
 --- 以下が議事録です ---
 {transcript}


### PR DESCRIPTION
## 変更点

✅ RSSフィード内の<description>要素の値が<![CDATA[ ... ]]>で囲って出力される
✅ <description>内のHTMLタグが、エスケープされずにそのまま維持される
✅ RSSフィード内の<itunes:summary>要素の値はCDATAで囲われない
✅ <itunes:summary>内のHTMLタグが正しくXML形式にエスケープされて出力される
✅ すべてのテストが合格し、既存のテストにも影響がない


## 関連Issue
- #80 

## テスト
<!-- 実施したテストと結果を記載 -->
- HTMLタグ（<p>, <br>）を含むテキストを入力した際、<description> がCDATAで囲まれ、タグがそのまま維持されていることを確認する単体テスト。
- 同様のテキストを入力した際、<itunes:summary> 側では < や > が正しくエスケープされていることを確認する単体テスト。

## 補足・備考
<!-- リスク、ロールバック、影響範囲、スクリーンショット等 -->
