### PR TITLE
fix: strip bot_token to remove trailing newline from Secret Manager

### DIFF
--- a/app/src/services/discord_fetcher.py
+++ b/app/src/services/discord_fetcher.py
@@ -36,8 +36,9 @@ class DiscordFetcher:
         Args:
             bot_token: Discord Bot Token。"Bot " プレフィックスは自動で付与する。
         """
+        # strip() で Secret Manager 経由の trailing newline など余分な空白を除去する
         self._headers = {
-            "Authorization": f"Bot {bot_token}",
+            "Authorization": f"Bot {bot_token.strip()}",
             "Content-Type": "application/json",
         }
 


### PR DESCRIPTION
## Problem
`discord-bot-token-dev` が trailing newline 付きで登録されていたため、`requests` が HTTP ヘッダーにセットする際に `ValueError` が発生。

```
ValueError: Invalid header value b'Bot <token>\n'
```

## Fix
`DiscordFetcher.__init__` で `bot_token.strip()` を適用。
Secret の登録方法によらず Authorization ヘッダーが常にクリーンな値になる。

## Note
- Secret version 2 (trailing newline なし) は登録済み
- version 1 (trailing newline あり) は disabled 済み
- このコード変更により、万一 Secret に空白が含まれても再発しない

🤖 Generated with [Claude Code](https://claude.com/claude-code)