### PR TITLE
feat: Phase 2-C extractor noise filtering and word-boundary fix

### DIFF
--- a/app/src/services/transcript_analyzer.py
+++ b/app/src/services/transcript_analyzer.py
@@ -349,6 +349,45 @@ _EPISODE_BOUNDARY_RE: re.Pattern[str] = re.compile(
     re.MULTILINE,
 )
 
+# podcast automator bot が投稿するメタデータ行のパターン。
+# extractor 側で弾くことで episode.content raw data は保持する。
+_METADATA_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"^New Podcast Processed", re.IGNORECASE),
+    re.compile(r"^Description\s*:"),
+    re.compile(r"^Title\s*:"),
+    re.compile(r"^URL\s*:"),
+    re.compile(r"^https?://"),
+]
+
+# 英語アクションキーワードの word-boundary パターン。
+# 'fix' が 'prefix' / 'fixing' などにヒットする substring match を防ぐ。
+_ACTION_WORD_BOUNDARY_RE: re.Pattern[str] = re.compile(
+    r"\b(fix|investigate|todo)\b",
+    re.IGNORECASE,
+)
+
+# 日本語アクションキーワード (substring match が適切)。
+# ACTION_KEYWORDS から英語分を除いたサブセット。
+_ACTION_KEYWORDS_JP: tuple[str, ...] = (
+    "やること",
+    "対応する",
+    "対応します",
+    "確認する",
+    "確認します",
+    "確認が必要",
+    "検討する",
+    "検討が必要",
+    "実装する",
+    "修正する",
+    "しておく",
+    "しなければ",
+    "必要がある",
+)
+
+# Discord markdown の行頭マーカー (bullet / blockquote) を除去するパターン。
+# ActionItem.text から * / - / > プレフィックスを取り除いて可読性を上げる。
+_MARKDOWN_STRIP_RE: re.Pattern[str] = re.compile(r"^[-*>]+\s*")
+
 
 # ── TranscriptAnalyzer ────────────────────────────────────────────────────────
 
@@ -587,7 +626,7 @@ class TranscriptAnalyzer:
         """
         return [
             ActionItem(
-                text=line.strip()[:200],
+                text=_MARKDOWN_STRIP_RE.sub("", line.strip())[:200],
                 source_episode=episode.number,
             )
             for episode in episodes
@@ -660,7 +699,10 @@ class TranscriptAnalyzer:
 
         PROMPT_PATTERNS の定義順(優先順位順)に評価し、
         最初にマッチした PromptType を返す。マッチなしは None。
+        metadata 行・短すぎる行は _is_noise_line() で事前に除外する。
         """
+        if self._is_noise_line(sentence):
+            return None
         for prompt_type, patterns in PROMPT_PATTERNS.items():
             for pattern in patterns:
                 if re.search(pattern, sentence):
@@ -670,14 +712,36 @@ class TranscriptAnalyzer:
     def _is_action_line(self, line: str) -> bool:
         """ACTION_KEYWORDS のいずれかを含む行かどうかを返す.
 
-        英語キーワード (fix, investigate, TODO) は case-insensitive で比較する。
-        日本語キーワードは大文字小文字の概念がないためそのまま比較する。
+        英語キーワード (fix, investigate, todo) は word-boundary regex で比較し、
+        'prefix' / 'fixing' などへの誤マッチを防ぐ。
+        日本語キーワードは大文字小文字の概念がないためそのまま substring で比較する。
+        metadata 行・短すぎる行は _is_noise_line() で事前に除外する。
         """
         stripped = line.strip()
         if not stripped:
             return False
-        line_lower = stripped.lower()
-        return any(kw.lower() in line_lower for kw in ACTION_KEYWORDS)
+        if self._is_noise_line(stripped):
+            return False
+        if _ACTION_WORD_BOUNDARY_RE.search(stripped):
+            return True
+        return any(kw in stripped for kw in _ACTION_KEYWORDS_JP)
+
+    def _is_noise_line(self, line: str) -> bool:
+        """ノイズ行(metadata・短すぎる行)かどうかを返す.
+
+        action item / discussion prompt の extractor が共通して呼ぶ negative filter。
+        episode.content の raw data は変更せず、extractor 側で除外することで
+        将来の LLM ベース解析に備えて raw transcript を保持する。
+
+        Args:
+            line: strip 済みの行文字列。
+
+        Returns:
+            True の場合はノイズとして除外すべき行。
+        """
+        if len(line) < 7:  # noqa: PLR2004
+            return True
+        return any(pat.search(line) for pat in _METADATA_PATTERNS)
 
     # ── プライベートヘルパー ───────────────────────────────────────────────────
 

--- a/app/tests/test_transcript_analyzer.py
+++ b/app/tests/test_transcript_analyzer.py
@@ -493,6 +493,325 @@ class TestExtractDiscussionPrompts:
         assert prompts == []
 
 
+class TestIsNoiseLine:
+    """_is_noise_line() ヘルパーのテストクラス."""
+
+    def test_short_line_is_noise(self):
+        """7 文字未満の行がノイズ判定されること."""
+        analyzer = TranscriptAnalyzer()
+        assert analyzer._is_noise_line("fix") is True  # 3 chars
+        assert analyzer._is_noise_line("URL:") is True  # 4 chars
+        assert analyzer._is_noise_line("abc") is True  # 3 chars
+
+    def test_description_prefix_is_noise(self):
+        """'Description:' で始まる行がノイズ判定されること."""
+        analyzer = TranscriptAnalyzer()
+        assert analyzer._is_noise_line("Description: <p>今後の方針を検討する</p>") is True
+        assert analyzer._is_noise_line("Description:<p>text</p>") is True
+
+    def test_title_prefix_is_noise(self):
+        """'Title:' で始まる行がノイズ判定されること."""
+        analyzer = TranscriptAnalyzer()
+        assert analyzer._is_noise_line("Title: Episode #22 - 設計回") is True
+
+    def test_url_prefix_is_noise(self):
+        """'URL:' で始まる行がノイズ判定されること."""
+        analyzer = TranscriptAnalyzer()
+        assert analyzer._is_noise_line("URL: https://example.com/episode/42") is True
+
+    def test_https_standalone_is_noise(self):
+        """'https://' で始まる行がノイズ判定されること."""
+        analyzer = TranscriptAnalyzer()
+        assert analyzer._is_noise_line("https://example.com/episode/42?utm_source=rss") is True
+
+    def test_new_podcast_processed_is_noise(self):
+        """'New Podcast Processed' で始まる行がノイズ判定されること."""
+        analyzer = TranscriptAnalyzer()
+        assert analyzer._is_noise_line("New Podcast Processed") is True
+
+    def test_normal_long_sentence_is_not_noise(self):
+        """通常の議論行(7 文字以上・metadata なし)がノイズ判定されないこと."""
+        analyzer = TranscriptAnalyzer()
+        assert analyzer._is_noise_line("このアーキテクチャはどう実装すべきか?") is False
+        assert analyzer._is_noise_line("Terraform の設定を見直した。") is False
+
+    def test_9char_sentence_is_not_noise(self):
+        """9 文字の文(7 文字閾値の境界値)がノイズ判定されないこと."""
+        analyzer = TranscriptAnalyzer()
+        # "どう設計すべきか?" = 9 chars — 既存テストの sentinel 値
+        assert analyzer._is_noise_line("どう設計すべきか?") is False
+
+
+class TestActionItemWordBoundary:
+    """action item の word-boundary マッチングのテストクラス."""
+
+    def test_fix_does_not_match_prefix(self):
+        """'prefix' に 'fix' の word-boundary マッチが発生しないこと."""
+        content = "#1 Meeting Transcript:\nprefixをコンポーネントに設定する。これは prefix 方式で動作する。"
+        episodes = _make_episodes_from_content(content)
+        analyzer = TranscriptAnalyzer()
+
+        items = analyzer.extract_action_items(episodes)
+
+        assert items == []
+
+    def test_fix_does_not_match_fixing(self):
+        """'fixing' に 'fix' の word-boundary マッチが発生しないこと."""
+        content = "#1 Meeting Transcript:\nWe are fixing the deploy pipeline issues."
+        episodes = _make_episodes_from_content(content)
+        analyzer = TranscriptAnalyzer()
+
+        items = analyzer.extract_action_items(episodes)
+
+        assert items == []
+
+    def test_fix_matches_standalone_word(self):
+        """'fix' が単語として現れた場合にアクションアイテムとして抽出されること."""
+        content = "#1 Meeting Transcript:\nfix: the deploy script before next release."
+        episodes = _make_episodes_from_content(content)
+        analyzer = TranscriptAnalyzer()
+
+        items = analyzer.extract_action_items(episodes)
+
+        assert len(items) == 1
+
+    def test_fix_matches_with_colon(self):
+        """'Fix:' 形式でもアクションアイテムとして抽出されること."""
+        content = "#1 Meeting Transcript:\nFix: API のレスポンス遅延を修正する。"
+        episodes = _make_episodes_from_content(content)
+        analyzer = TranscriptAnalyzer()
+
+        items = analyzer.extract_action_items(episodes)
+
+        assert len(items) == 1
+
+    def test_investigate_does_not_match_reinvestigate(self):
+        """'reinvestigate' に 'investigate' の word-boundary マッチが発生しないこと."""
+        content = "#1 Meeting Transcript:\nWe may need to reinvestigate the root cause later."
+        episodes = _make_episodes_from_content(content)
+        analyzer = TranscriptAnalyzer()
+
+        items = analyzer.extract_action_items(episodes)
+
+        assert items == []
+
+    def test_todo_matches_with_colon(self):
+        """'TODO:' 形式でもアクションアイテムとして抽出されること."""
+        content = "#1 Meeting Transcript:\nTODO: Cloud Scheduler の設定を確認する"
+        episodes = _make_episodes_from_content(content)
+        analyzer = TranscriptAnalyzer()
+
+        items = analyzer.extract_action_items(episodes)
+
+        assert len(items) == 1
+
+
+class TestActionItemMarkdownStrip:
+    """ActionItem.text の markdown marker strip のテストクラス."""
+
+    def test_bullet_asterisk_stripped(self):
+        """'* keyword' の leading '* ' が ActionItem.text から除去されること."""
+        content = "#1 Meeting Transcript:\n* TODO: Cloud Scheduler の設定を確認する"
+        episodes = _make_episodes_from_content(content)
+        analyzer = TranscriptAnalyzer()
+
+        items = analyzer.extract_action_items(episodes)
+
+        assert len(items) == 1
+        assert not items[0].text.startswith("*")
+        assert "TODO" in items[0].text
+
+    def test_bullet_dash_stripped(self):
+        """'- keyword' の leading '- ' が ActionItem.text から除去されること."""
+        content = "#1 Meeting Transcript:\n- 対応する: Webhook URL を更新する"
+        episodes = _make_episodes_from_content(content)
+        analyzer = TranscriptAnalyzer()
+
+        items = analyzer.extract_action_items(episodes)
+
+        assert len(items) == 1
+        assert not items[0].text.startswith("-")
+
+    def test_blockquote_marker_stripped(self):
+        """'> keyword' の leading '> ' が ActionItem.text から除去されること."""
+        content = "#1 Meeting Transcript:\n> 確認する: GCP の billing を見直す"
+        episodes = _make_episodes_from_content(content)
+        analyzer = TranscriptAnalyzer()
+
+        items = analyzer.extract_action_items(episodes)
+
+        assert len(items) == 1
+        assert not items[0].text.startswith(">")
+
+    def test_no_marker_line_text_unchanged(self):
+        """markdown marker のない行は変更されないこと."""
+        content = "#1 Meeting Transcript:\nTODO: Cloud Scheduler の設定を確認する"
+        episodes = _make_episodes_from_content(content)
+        analyzer = TranscriptAnalyzer()
+
+        items = analyzer.extract_action_items(episodes)
+
+        assert len(items) == 1
+        assert items[0].text.startswith("TODO:")
+
+
+class TestExtractorNoiseFiltering:
+    """metadata ノイズが action_items / discussion_prompts から除外されること."""
+
+    def test_description_html_excluded_from_action_items(self):
+        """'Description: <p>...' 行が action_items に含まれないこと."""
+        content = "#1 Meeting Transcript:\nDescription: <p>今後の方針を検討する必要があります</p>"
+        episodes = _make_episodes_from_content(content)
+        analyzer = TranscriptAnalyzer()
+
+        items = analyzer.extract_action_items(episodes)
+
+        assert items == []
+
+    def test_description_html_excluded_from_prompts(self):
+        """'Description: <p>...' 行が discussion_prompts に含まれないこと."""
+        content = "#1 Meeting Transcript:\nDescription: <p>今後の方針を検討する必要があります</p>"
+        episodes = _make_episodes_from_content(content)
+        analyzer = TranscriptAnalyzer()
+
+        prompts = analyzer.extract_discussion_prompts(episodes)
+
+        assert prompts == []
+
+    def test_url_line_excluded_from_action_items(self):
+        """'URL:' 行が action_items に含まれないこと."""
+        content = "#1 Meeting Transcript:\nURL: https://example.com/episode/42"
+        episodes = _make_episodes_from_content(content)
+        analyzer = TranscriptAnalyzer()
+
+        items = analyzer.extract_action_items(episodes)
+
+        assert items == []
+
+    def test_url_line_excluded_from_prompts(self):
+        """'URL:' 行が discussion_prompts に含まれないこと."""
+        content = "#1 Meeting Transcript:\nURL: https://example.com/episode/42"
+        episodes = _make_episodes_from_content(content)
+        analyzer = TranscriptAnalyzer()
+
+        prompts = analyzer.extract_discussion_prompts(episodes)
+
+        assert prompts == []
+
+    def test_standalone_https_excluded_from_prompts(self):
+        """'https://...' 行が discussion_prompts に含まれないこと."""
+        content = "#1 Meeting Transcript:\nhttps://podcast.example.com/ep/42?utm_source=rss"
+        episodes = _make_episodes_from_content(content)
+        analyzer = TranscriptAnalyzer()
+
+        prompts = analyzer.extract_discussion_prompts(episodes)
+
+        assert prompts == []
+
+    def test_new_podcast_processed_excluded_from_prompts(self):
+        """'New Podcast Processed' 行が discussion_prompts に含まれないこと."""
+        content = "#1 Meeting Transcript:\nNew Podcast Processed"
+        episodes = _make_episodes_from_content(content)
+        analyzer = TranscriptAnalyzer()
+
+        prompts = analyzer.extract_discussion_prompts(episodes)
+
+        assert prompts == []
+
+    def test_new_podcast_processed_excluded_from_action_items(self):
+        """'New Podcast Processed' 行が action_items に含まれないこと."""
+        content = "#1 Meeting Transcript:\nNew Podcast Processed"
+        episodes = _make_episodes_from_content(content)
+        analyzer = TranscriptAnalyzer()
+
+        items = analyzer.extract_action_items(episodes)
+
+        assert items == []
+
+    def test_mixed_metadata_and_real_content(self):
+        """metadata ノイズと実コンテンツが混在しても実コンテンツだけ抽出されること."""
+        content = (
+            "#22 Meeting Transcript:\n"
+            "New Podcast Processed\n"
+            "Description: <p>今後の方針を確認する必要があります</p>\n"
+            "URL: https://example.com/episode/22\n"
+            "TODO: Cloud Scheduler の設定を確認する\n"
+            "アーキテクチャの方針はどう設計すべきか?"
+        )
+        episodes = _make_episodes_from_content(content)
+        analyzer = TranscriptAnalyzer()
+
+        items = analyzer.extract_action_items(episodes)
+        prompts = analyzer.extract_discussion_prompts(episodes)
+
+        # metadata は除外され、実コンテンツのみ抽出される
+        assert len(items) == 1
+        assert "TODO" in items[0].text
+        assert all("Description" not in item.text for item in items)
+        assert all("URL" not in item.text for item in items)
+        assert all("New Podcast" not in item.text for item in items)
+        assert len(prompts) >= 1
+        assert any(p.prompt_type == PromptType.design_decision for p in prompts)
+
+    def test_prompts_count_reduced_vs_noisy_baseline(self):
+        """metadata を含む episode でも noise 除去後の prompts 件数が合理的範囲に収まること."""
+        # metadata ノイズを多数含む content
+        content = (
+            "#22 Meeting Transcript:\n"
+            "New Podcast Processed\n"
+            "Description: <p>今後の方針を検討する。将来的な設計方針はどうするか</p>\n"
+            "URL: https://example.com/episode/22\n"
+            "https://another-link.com/episode?utm_source=rss\n"
+            # 実コンテンツ
+            "AI / LLM を活用したアジェンダ生成を今後進めたい。\n"
+            "アーキテクチャの設計はどう実装すべきか?\n"
+        )
+        episodes = _make_episodes_from_content(content)
+        analyzer = TranscriptAnalyzer()
+
+        prompts = analyzer.extract_discussion_prompts(episodes)
+
+        # metadata 行は除外されるため、実コンテンツ由来のみ: 最大 2 件程度
+        assert len(prompts) <= 3
+
+
+class TestDiscussionPromptNoiseFiltering:
+    """discussion_prompts の noise guard / minimum length テストクラス."""
+
+    def test_very_short_sentence_not_extracted(self):
+        """6 文字以下の文(閾値未満)が discussion_prompt に含まれないこと."""
+        # "設計?" = 3 chars → noise
+        content = "#1 Meeting Transcript:\n設計?"
+        episodes = _make_episodes_from_content(content)
+        analyzer = TranscriptAnalyzer()
+
+        prompts = analyzer.extract_discussion_prompts(episodes)
+
+        assert prompts == []
+
+    def test_9char_uncertain_sentence_is_extracted(self):
+        """9 文字の文(閾値以上)が正しく抽出されること."""
+        # "どう設計すべきか?" = 9 chars — 7 文字閾値をちょうど超える
+        content = "#1 Meeting Transcript:\nどう設計すべきか?"
+        episodes = _make_episodes_from_content(content)
+        analyzer = TranscriptAnalyzer()
+
+        prompts = analyzer.extract_discussion_prompts(episodes)
+
+        assert len(prompts) >= 1
+
+    def test_normal_uncertain_sentence_extracted(self):
+        """11 文字以上の uncertain 行が正しく抽出されること."""
+        # "詳細はまだ検討中です。" = 11 chars
+        content = "#1 Meeting Transcript:\n詳細はまだ検討中です。"
+        episodes = _make_episodes_from_content(content)
+        analyzer = TranscriptAnalyzer()
+
+        prompts = analyzer.extract_discussion_prompts(episodes)
+
+        assert any(p.prompt_type == PromptType.uncertain for p in prompts)
+
+
 class TestPhase1BIntegration:
     """Phase 1-B 全体パイプラインの integration テスト."""
 


### PR DESCRIPTION
## 概要

dynamic agenda の抽出品質改善。podcast 投稿メタデータ行 (`Description:`/`URL:`/`New Podcast Processed`) が `action_items` / `discussion_prompts` に混入する問題を修正する。

## 変更内容

### `transcript_analyzer.py` (extractor 側のみ修正)

| 追加 | 内容 |
|---|---|
| `_METADATA_PATTERNS` | podcast metadata 行を検出する regex パターン群 |
| `_ACTION_WORD_BOUNDARY_RE` | `fix`/`investigate`/`todo` の word-boundary regex (`prefix`/`fixing` 誤マッチ防止) |
| `_ACTION_KEYWORDS_JP` | 日本語アクションキーワード (substring match) |
| `_MARKDOWN_STRIP_RE` | ActionItem.text の leading `*`/`-`/`>` strip |
| `_is_noise_line()` | metadata 行・7文字未満を noise と判定する共通 negative filter |

修正メソッド:
- `_is_action_line()`: noise guard + word-boundary matching
- `extract_action_items()`: markdown marker strip
- `_classify_sentence()`: noise guard

### `test_transcript_analyzer.py`

新規テストクラス:
- `TestIsNoiseLine` — metadata / 短行境界値
- `TestActionItemWordBoundary` — `fix` vs `prefix`/`fixing`
- `TestActionItemMarkdownStrip` — `*`/`-`/`>` strip
- `TestExtractorNoiseFiltering` — Description: / URL: / New Podcast 除外
- `TestDiscussionPromptNoiseFiltering` — 短文・9文字境界値

既存 33 テスト全通過 + 新規 30 テスト追加 = 計 63 テスト

## 設計方針

- `episode.content` raw data は変更しない (将来の LLM 解析に備えて保持)
- formatter / agenda_main.py / Terraform 変更なし
- pure logic 維持 (I/O 禁止)

## runtime での期待改善

- `description:<p>...` が action_items / prompts から消失
- `URL:` 行が消失
- `*` などの markdown marker が ActionItem.text から除去
- `prompts` 件数の減少 (46 → 推定 20 以下)

🤖 Generated with [Claude Code](https://claude.com/claude-code)