### PR TITLE
feat(phase-3c): integrate RSS news fetch and Discord formatter

### DIFF
--- a/app/src/agenda_main.py
+++ b/app/src/agenda_main.py
@@ -5,6 +5,7 @@
 
 Phase 1-A: Discord transcript チャンネルから過去議事録を取得し、
            Episode に再構築して AgendaResult を JSON として出力する検証フェーズ。
+Phase 3-C: RSS ニュースを取得し、アジェンダトピックとの関連度でマッチングして通知する。
 """
 
 from __future__ import annotations
@@ -18,6 +19,8 @@ from pathlib import Path
 
 from services.agenda_formatter import format_agenda_message
 from services.discord_fetcher import DiscordFetcher
+from services.news_fetcher import DEFAULT_RSS_SOURCES, NewsFetcher
+from services.news_relevance import NewsCandidate, match_news_to_agenda
 from services.notifier import Notifier
 from services.transcript_analyzer import AgendaResult, TranscriptAnalyzer
 
@@ -41,21 +44,23 @@ AGENDA_MESSAGE = (
 )
 
 
-def _fetch_and_reconstruct() -> tuple[AgendaResult | None, list[str]]:
-    """Discord transcript チャンネルからメッセージを取得して Episode を再構築する.
+def _fetch_and_reconstruct() -> tuple[AgendaResult | None, list[str], list[NewsCandidate]]:
+    """Discord transcript チャンネルからメッセージを取得して Episode を再構築し、ニュースをマッチングする.
 
-    DISCORD_BOT_TOKEN / DISCORD_TRANSCRIPT_CHANNEL_ID が未設定の場合は (None, []) を返す。
+    DISCORD_BOT_TOKEN / DISCORD_TRANSCRIPT_CHANNEL_ID が未設定の場合は (None, [], []) を返す。
+    news fetch / match が失敗した場合は空リストで継続する (non-fatal)。
 
     Returns:
-        (result, warnings) のタプル。
+        (result, warnings, news_candidates) のタプル。
         result: AgendaResult。Bot Token / Channel ID 未設定時は None。
         warnings: reconstruct_episodes() が収集した警告メッセージ。
+        news_candidates: ニュースマッチング結果。取得失敗時は空リスト。
     """
     if not _DISCORD_BOT_TOKEN or not _DISCORD_TRANSCRIPT_CHANNEL_ID:
         logger.info(
             "DISCORD_BOT_TOKEN / DISCORD_TRANSCRIPT_CHANNEL_ID が未設定のため transcript 取得をスキップします。",
         )
-        return None, []
+        return None, [], []
 
     fetcher = DiscordFetcher(bot_token=_DISCORD_BOT_TOKEN)
     messages = fetcher.fetch_messages(
@@ -95,7 +100,19 @@ def _fetch_and_reconstruct() -> tuple[AgendaResult | None, list[str]]:
         analysis_window_size=_TRANSCRIPT_FETCH_LIMIT,
         fetched_message_count=len(messages),
     )
-    return result, warnings
+
+    # Phase 3-C: RSS ニュース取得 → アジェンダトピックとのマッチング
+    # fetch / match の失敗は non-fatal: 空リストで継続し Discord 投稿はそのまま行う。
+    news_candidates: list[NewsCandidate] = []
+    try:
+        news_items = NewsFetcher().fetch_all(DEFAULT_RSS_SOURCES)
+        logger.info("Fetched %d news items from RSS.", len(news_items))
+        news_candidates = match_news_to_agenda(news_items, result)
+        logger.info("Matched %d news candidates.", len(news_candidates))
+    except Exception:  # noqa: BLE001
+        logger.warning("News fetch/match failed. Continuing without news.", exc_info=True)
+
+    return result, warnings, news_candidates
 
 
 def _export_debug_json(result: AgendaResult, path: str) -> None:
@@ -125,11 +142,12 @@ def send_weekly_agenda() -> None:
 
     logger.info("DISCORD_WEBHOOK_AGENDA_URL configured: %s", bool(DISCORD_WEBHOOK_AGENDA_URL))
 
-    # Phase 1-A: transcript 取得・Episode 再構築
+    # transcript 取得・Episode 再構築・ニュースマッチング
     # 失敗しても reminder 通知自体は継続するため try/except で隔離する
     result: AgendaResult | None = None
+    news_candidates: list[NewsCandidate] = []
     try:
-        result, _warnings = _fetch_and_reconstruct()
+        result, _warnings, news_candidates = _fetch_and_reconstruct()
     except Exception:
         logger.exception("Transcript analysis failed. Falling back to fixed-message notification.")
 
@@ -142,7 +160,7 @@ def send_weekly_agenda() -> None:
         )
         if _DEBUG_JSON_PATH:
             _export_debug_json(result, _DEBUG_JSON_PATH)
-        message = format_agenda_message(result)
+        message = format_agenda_message(result, news_candidates=news_candidates)
     else:
         # transcript analysis がスキップまたは失敗した場合は固定文に fallback
         message = AGENDA_MESSAGE

--- a/app/src/services/agenda_formatter.py
+++ b/app/src/services/agenda_formatter.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from services.news_relevance import NewsCandidate
     from services.transcript_analyzer import (
         ActionItem,
         AgendaResult,
@@ -23,16 +24,18 @@ if TYPE_CHECKING:
 # Discord が許容する 1 メッセージの文字数上限 (実際は 2000 だが余裕を持たせる)
 _MAX_MESSAGE_LENGTH: int = 1900
 
-# action_item / discussion_prompt の 1 行あたりの最大文字数 (後続の [#N] を含まない)
+# action_item / discussion_prompt / news title の 1 行あたりの最大文字数
 _MAX_LINE_LENGTH: int = 80
 
 
 def format_agenda_message(
     result: AgendaResult,
     *,
-    max_themes: int = 5,
-    max_items: int = 5,
-    max_prompts: int = 5,
+    news_candidates: list[NewsCandidate] | None = None,
+    max_themes: int = 3,
+    max_items: int = 0,
+    max_prompts: int = 3,
+    max_news: int = 3,
 ) -> str:
     """AgendaResult を Discord 投稿用 markdown 文字列に整形する.
 
@@ -40,10 +43,11 @@ def format_agenda_message(
 
     セクション構成:
       1. ヘッダー (常に表示)
-      2. 繰り返しトピック (0 件の場合は省略)
-      3. アクションアイテム (0 件の場合は省略)
-      4. 未解決の論点 (0 件の場合は省略)
-      5. フッター (常に表示)
+      2. 最近よく出てきたテーマ (0 件の場合は省略)
+      3. 最近の会話と繋がりそうなニュース (news_candidates が None / 空の場合は省略)
+      4. アクションアイテム (max_items=0 の場合は省略 / デフォルト非表示)
+      5. 気になっている問い (0 件の場合は省略)
+      6. フッター (常に表示)
 
     長さ制御:
       ヘッダーとフッターを先に確保し、残りの budget に収まるセクションのみ
@@ -51,23 +55,25 @@ def format_agenda_message(
 
     Args:
         result: フォーマット対象の AgendaResult。
+        news_candidates: ニュース候補リスト。None または空の場合はニュースセクションを省略。
         max_themes: 表示する recurring_themes の最大件数。
-        max_items: 表示する action_items の最大件数。
+        max_items: 表示する action_items の最大件数。0 の場合はセクション非表示 (デフォルト)。
         max_prompts: 表示する discussion_prompts の最大件数。
+        max_news: 表示する news_candidates の最大件数。
 
     Returns:
         Discord markdown 形式の文字列。_MAX_MESSAGE_LENGTH 以内に収まる。
     """
-    header = "📅 **今週の収録リマインダー**"
-    footer = _build_footer(result)
+    header = "🎙️ **今週の会話のタネ**"
+    footer = _build_footer(result, news_candidates)
 
     # ヘッダー、フッター、区切り文字分を先に予算から差し引く
-    # 区切りは "\n\n" = 2 chars。header と footer の間に最低 1 つ必要。
     base_cost = len(header) + 2 + len(footer)
     budget = _MAX_MESSAGE_LENGTH - base_cost
 
     candidate_sections = [
         _build_themes_section(result.recurring_themes[:max_themes]),
+        _build_news_section((news_candidates or [])[:max_news]),
         _build_items_section(result.action_items[:max_items]),
         _build_prompts_section(result.discussion_prompts[:max_prompts]),
     ]
@@ -89,14 +95,30 @@ def format_agenda_message(
 
 
 def _build_themes_section(themes: list[TopicMatch]) -> str | None:
-    """recurring_themes セクションを構築する。0 件の場合は None を返す."""
+    """テーマセクションを構築する。0 件の場合は None を返す."""
     if not themes:
         return None
-    lines = ["🔁 **繰り返しトピック**"]
-    for theme in themes:
-        refs = _format_episode_refs(theme.evidence)
-        suffix = f" {refs}" if refs else ""
-        lines.append(f"・{theme.display_name}{suffix}")
+    lines = ["🧵 **最近よく出てきたテーマ**"]
+    lines.extend(f"・{theme.display_name}" for theme in themes)
+    return "\n".join(lines)
+
+
+def _build_news_section(candidates: list[NewsCandidate]) -> str | None:
+    """ニュースセクションを構築する。0 件の場合は None を返す.
+
+    1 件あたり 2 行:
+      ・{title} ({source})
+        ↳ {topic}
+    """
+    if not candidates:
+        return None
+    lines = ["🗞️ **最近の会話と繋がりそうなニュース**"]
+    for c in candidates:
+        title = _truncate(c.news_item.title, _MAX_LINE_LENGTH)
+        source = c.news_item.source
+        topic = c.topic_match.display_name
+        lines.append(f"・{title} ({source})")
+        lines.append(f"  ↳ {topic}")
     return "\n".join(lines)
 
 
@@ -115,16 +137,21 @@ def _build_prompts_section(prompts: list[DiscussionPrompt]) -> str | None:
     """discussion_prompts セクションを構築する。0 件の場合は None を返す."""
     if not prompts:
         return None
-    lines = ["❓ **未解決の論点**"]
+    lines = ["💡 **気になっている問い**"]
     for prompt in prompts:
         sentence = _truncate(prompt.sentence, _MAX_LINE_LENGTH)
         lines.append(f"・{sentence} [#{prompt.source_episode}]")
     return "\n".join(lines)
 
 
-def _build_footer(result: AgendaResult) -> str:
-    """分析メタデータのフッターを構築する."""
+def _build_footer(result: AgendaResult, news_candidates: list[NewsCandidate] | None = None) -> str:
+    """分析メタデータのフッターを構築する.
+
+    news_candidates が存在する場合はニュース接続件数を表示する。
+    """
     ep_count = result.analyzed_episodes
+    if news_candidates:
+        return f"📊 *{ep_count} エピソード / {len(news_candidates)} ニュース接続*"
     fetched = result.metadata.fetched_message_count
     return f"📊 *分析: {ep_count} エピソード / {fetched} 件取得*"
 
@@ -135,8 +162,8 @@ def _build_footer(result: AgendaResult) -> str:
 def _format_episode_refs(evidence: list[MentionEvidence]) -> str:
     """Evidence リストからエピソード参照文字列 (#N, #M, ...) を生成する.
 
-    Evidence は最大 3 件に制限されているため、全エピソードが反映されない場合がある。
     重複するエピソード番号は排除し、登場順を維持する。
+    現在は formatter 内では未使用だが、外部からのテスト用に公開を維持する。
     """
     seen: set[int] = set()
     ep_nums: list[int] = []

--- a/app/tests/test_agenda_formatter.py
+++ b/app/tests/test_agenda_formatter.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+
 from services.agenda_formatter import (
     _MAX_MESSAGE_LENGTH,
     _format_episode_refs,
     _truncate,
     format_agenda_message,
 )
+from services.news_fetcher import NewsItem
+from services.news_relevance import NewsCandidate
 from services.transcript_analyzer import (
     ActionItem,
     AgendaMetadata,
@@ -91,6 +95,28 @@ def _make_prompt(
     )
 
 
+def _make_news_candidate(
+    *,
+    title: str = "Claude 4 context window expanded to 1M tokens",
+    source: str = "Hacker News",
+    url: str = "https://news.ycombinator.com/item?id=12345",
+    topic_display_name: str = "AI / LLM 活用",
+    score: float = 0.5,
+) -> NewsCandidate:
+    news_item = NewsItem(
+        title=title,
+        url=url,
+        source=source,
+        published_at=datetime(2024, 1, 15, 0, 0, 0, tzinfo=UTC),
+    )
+    topic_match = _make_theme(display_name=topic_display_name)
+    return NewsCandidate(
+        news_item=news_item,
+        topic_match=topic_match,
+        score=score,
+    )
+
+
 # ── TestFormatAgendaMessage ────────────────────────────────────────────────────
 
 
@@ -101,7 +127,7 @@ class TestFormatAgendaMessage:
         """ヘッダーが常に含まれること."""
         result = _make_result()
         msg = format_agenda_message(result)
-        assert "今週の収録リマインダー" in msg
+        assert "今週の会話のタネ" in msg
 
     def test_footer_always_present(self):
         """フッター (分析メタデータ) が常に含まれること."""
@@ -110,52 +136,69 @@ class TestFormatAgendaMessage:
         assert "3 エピソード" in msg
         assert "50 件取得" in msg
 
+    def test_footer_shows_news_count_when_candidates_given(self):
+        """news_candidates が渡された場合、フッターにニュース接続件数が表示されること."""
+        result = _make_result(analyzed_episodes=11, fetched=50)
+        candidates = [_make_news_candidate(), _make_news_candidate(title="Another news")]
+        msg = format_agenda_message(result, news_candidates=candidates)
+        assert "11 エピソード" in msg
+        assert "2 ニュース接続" in msg
+        # "件取得" は news あり時は表示しない
+        assert "件取得" not in msg
+
     def test_all_sections_present_when_data_exists(self):
-        """全セクションにデータがある場合、3 セクションすべて含まれること."""
+        """全セクションにデータがある場合、テーマ・ニュース・論点セクションが含まれること."""
         result = _make_result(
             themes=[_make_theme()],
             items=[_make_item()],
             prompts=[_make_prompt()],
         )
-        msg = format_agenda_message(result)
-        assert "繰り返しトピック" in msg
+        candidates = [_make_news_candidate()]
+        msg = format_agenda_message(result, news_candidates=candidates, max_items=3)
+        assert "最近よく出てきたテーマ" in msg
+        assert "最近の会話と繋がりそうなニュース" in msg
         assert "アクションアイテム" in msg
-        assert "未解決の論点" in msg
+        assert "気になっている問い" in msg
 
     def test_empty_themes_section_omitted(self):
         """recurring_themes が 0 件の場合、テーマセクションが省略されること."""
         result = _make_result(themes=[], items=[_make_item()])
         msg = format_agenda_message(result)
-        assert "繰り返しトピック" not in msg
+        assert "最近よく出てきたテーマ" not in msg
 
     def test_empty_items_section_omitted(self):
         """action_items が 0 件の場合、アクションアイテムセクションが省略されること."""
         result = _make_result(themes=[_make_theme()], items=[])
-        msg = format_agenda_message(result)
+        msg = format_agenda_message(result, max_items=5)
+        assert "アクションアイテム" not in msg
+
+    def test_items_section_omitted_by_default(self):
+        """max_items=0 (デフォルト) の場合、アクションアイテムセクションが省略されること."""
+        result = _make_result(themes=[_make_theme()], items=[_make_item()])
+        msg = format_agenda_message(result)  # max_items=0 がデフォルト
         assert "アクションアイテム" not in msg
 
     def test_empty_prompts_section_omitted(self):
         """discussion_prompts が 0 件の場合、論点セクションが省略されること."""
         result = _make_result(themes=[_make_theme()], prompts=[])
         msg = format_agenda_message(result)
-        assert "未解決の論点" not in msg
+        assert "気になっている問い" not in msg
 
     def test_all_empty_shows_only_header_and_footer(self):
         """全セクション空の場合、ヘッダーとフッターのみ含まれること."""
         result = _make_result()
         msg = format_agenda_message(result)
-        assert "今週の収録リマインダー" in msg
+        assert "今週の会話のタネ" in msg
         assert "エピソード" in msg
-        assert "繰り返しトピック" not in msg
+        assert "最近よく出てきたテーマ" not in msg
         assert "アクションアイテム" not in msg
-        assert "未解決の論点" not in msg
+        assert "気になっている問い" not in msg
 
     def test_max_themes_limit_applied(self):
         """max_themes を超えるテーマが切り捨てられること."""
         themes = [_make_theme(topic_id=f"t{i}", display_name=f"Topic {i}") for i in range(10)]
         result = _make_result(themes=themes)
         msg = format_agenda_message(result, max_themes=3)
-        # Topic 0, 1, 2 は含まれ、Topic 3 以降は含まれない
         assert "Topic 0" in msg
         assert "Topic 2" in msg
         assert "Topic 3" not in msg
@@ -182,9 +225,8 @@ class TestFormatAgendaMessage:
         """80 字を超えるアクションアイテムのテキストが切り捨てられること."""
         long_text = "TODO: " + "あ" * 100
         result = _make_result(items=[_make_item(text=long_text)])
-        msg = format_agenda_message(result)
+        msg = format_agenda_message(result, max_items=1)
         assert "..." in msg
-        # 全文がそのまま含まれていないこと
         assert long_text not in msg
 
     def test_long_prompt_truncated(self):
@@ -200,22 +242,25 @@ class TestFormatAgendaMessage:
         themes = [_make_theme(topic_id=f"t{i}", display_name=f"Topic {i}") for i in range(5)]
         items = [_make_item(text=f"TODO: {'あ' * 80}", source_episode=i) for i in range(5)]
         prompts = [_make_prompt(sentence=f"{'設計' * 40}?", source_episode=i) for i in range(5)]
+        candidates = [_make_news_candidate(title=f"News item {i}" * 5) for i in range(5)]
         result = _make_result(themes=themes, items=items, prompts=prompts)
-        msg = format_agenda_message(result)
+        msg = format_agenda_message(result, news_candidates=candidates)
         assert len(msg) <= _MAX_MESSAGE_LENGTH
 
-    def test_episode_ref_shown_in_themes(self):
-        """recurring_theme にエピソード参照が含まれること."""
-        theme = _make_theme(evidence_episodes=[1, 2])
+    def test_themes_section_shows_display_name_without_episode_refs(self):
+        """recurring_theme のトピック名が表示され、エピソード参照が含まれないこと."""
+        theme = _make_theme(display_name="インフラ / Terraform", evidence_episodes=[1, 2])
         result = _make_result(themes=[theme])
         msg = format_agenda_message(result)
-        assert "#1" in msg
-        assert "#2" in msg
+        assert "インフラ / Terraform" in msg
+        # エピソード参照は themes セクションに表示しない
+        assert "(#1" not in msg
+        assert "(#2" not in msg
 
     def test_source_episode_shown_in_action_items(self):
         """action_item にエピソード番号が含まれること."""
         result = _make_result(items=[_make_item(source_episode=3)])
-        msg = format_agenda_message(result)
+        msg = format_agenda_message(result, max_items=1)
         assert "[#3]" in msg
 
     def test_source_episode_shown_in_prompts(self):
@@ -226,20 +271,89 @@ class TestFormatAgendaMessage:
 
     def test_section_budget_overflow_skips_section(self):
         """budget を超えるセクションが丸ごとスキップされること."""
-        # テーマセクションだけで budget を埋める大量データ
-        # 実際には _MAX_MESSAGE_LENGTH に近い状況を人工的に作るのが難しいため、
-        # budget を最小値に絞った custom call で確認する
         result = _make_result(
             themes=[_make_theme()],
             items=[_make_item()],
             prompts=[_make_prompt()],
         )
-        # max_items=0 相当: items が空として扱われるのでセクション省略を確認
         msg = format_agenda_message(result, max_items=0)
         assert "アクションアイテム" not in msg
-        # themes と prompts は残る
-        assert "繰り返しトピック" in msg
-        assert "未解決の論点" in msg
+        assert "最近よく出てきたテーマ" in msg
+        assert "気になっている問い" in msg
+
+
+# ── TestNewsSectionBuilding ────────────────────────────────────────────────────
+
+
+class TestNewsSectionBuilding:
+    """news section の構築テストクラス."""
+
+    def test_news_section_shown_with_candidates(self):
+        """news_candidates が渡された場合、ニュースセクションが表示されること."""
+        result = _make_result()
+        candidates = [_make_news_candidate()]
+        msg = format_agenda_message(result, news_candidates=candidates)
+        assert "最近の会話と繋がりそうなニュース" in msg
+
+    def test_news_section_omitted_when_none(self):
+        """news_candidates=None の場合、ニュースセクションが省略されること."""
+        result = _make_result()
+        msg = format_agenda_message(result, news_candidates=None)
+        assert "最近の会話と繋がりそうなニュース" not in msg
+
+    def test_news_section_omitted_when_empty_list(self):
+        """news_candidates=[] の場合、ニュースセクションが省略されること."""
+        result = _make_result()
+        msg = format_agenda_message(result, news_candidates=[])
+        assert "最近の会話と繋がりそうなニュース" not in msg
+
+    def test_news_title_and_source_in_message(self):
+        """ニュースのタイトルとソースがメッセージに含まれること."""
+        result = _make_result()
+        candidate = _make_news_candidate(
+            title="Cloud Run gen2 cold start improvements",
+            source="Google Cloud Blog",
+        )
+        msg = format_agenda_message(result, news_candidates=[candidate])
+        assert "Cloud Run gen2 cold start improvements" in msg
+        assert "Google Cloud Blog" in msg
+
+    def test_news_topic_connection_in_message(self):
+        """ニュースのトピック接続先 (↳ {topic}) がメッセージに含まれること."""
+        result = _make_result()
+        candidate = _make_news_candidate(topic_display_name="インフラ / Terraform")
+        msg = format_agenda_message(result, news_candidates=[candidate])
+        assert "インフラ / Terraform" in msg
+        assert "↳" in msg
+
+    def test_max_news_limit_applied(self):
+        """max_news を超えるニュース候補が切り捨てられること."""
+        result = _make_result()
+        candidates = [_make_news_candidate(title=f"News {i}", url=f"https://example.com/{i}") for i in range(10)]
+        msg = format_agenda_message(result, news_candidates=candidates, max_news=2)
+        assert "News 0" in msg
+        assert "News 1" in msg
+        assert "News 2" not in msg
+
+    def test_long_news_title_truncated(self):
+        """80 字を超えるニュースタイトルが切り捨てられること."""
+        long_title = "A" * 100
+        result = _make_result()
+        candidate = _make_news_candidate(title=long_title)
+        msg = format_agenda_message(result, news_candidates=[candidate])
+        assert "..." in msg
+        assert long_title not in msg
+
+    def test_message_with_news_within_length_limit(self):
+        """ニュースセクションを含むメッセージが _MAX_MESSAGE_LENGTH 以内に収まること."""
+        themes = [_make_theme(topic_id=f"t{i}", display_name=f"Topic {i}") for i in range(3)]
+        prompts = [_make_prompt(sentence=f"設計方針 {i} はどうすべきか?") for i in range(3)]
+        candidates = [
+            _make_news_candidate(title=f"News article {i}" * 3, url=f"https://example.com/{i}") for i in range(3)
+        ]
+        result = _make_result(themes=themes, prompts=prompts)
+        msg = format_agenda_message(result, news_candidates=candidates)
+        assert len(msg) <= _MAX_MESSAGE_LENGTH
 
 
 # ── TestFormatEpisodeRefs ──────────────────────────────────────────────────────


### PR DESCRIPTION
- agenda_main: fetch RSS news and match to agenda topics via match_news_to_agenda()
  - news fetch/match is non-fatal: falls back to news_candidates=[] on error
  - passes news_candidates to format_agenda_message()

- agenda_formatter: add news section and UX-oriented rewrite
  - new header: '今週の会話のタネ' (conversation seeds, not meeting summary)
  - new section: '最近の会話と繋がりそうなニュース' with title/source/topic-connection lines
  - section order: themes → news → items → prompts
  - footer shows news connection count when candidates present
  - max_items defaults to 0 (action items hidden by default)
  - budget-managed: sections skipped if over 1900-char limit

- test_agenda_formatter: updated wording assertions + TestNewsSectionBuilding (8 tests)

Phase 3-C goal: observe what transcript × news connections look like in practice. False positives acceptable. Runtime stability > relevance quality.

## 変更点
<!-- 箇条書きで具体的に -->
-

## 関連Issue
<!-- 例: Fixes #123 / Fixes #123, #456 -->
-

## テスト
<!-- 実施したテストと結果を記載 -->
-

## 補足・備考
<!-- リスク、ロールバック、影響範囲、スクリーンショット等 -->
