### PR TITLE
fix: CDで未準備リソースを作成しないようにする

### DIFF
--- a/infrastructure/firestore.tf
+++ b/infrastructure/firestore.tf
@@ -1,4 +1,6 @@
 resource "google_firestore_database" "database" {
+  count = var.manage_firestore_database ? 1 : 0
+
   project     = var.project_id
   name        = "(default)"
   location_id = var.region

--- a/infrastructure/promoter.tf
+++ b/infrastructure/promoter.tf
@@ -8,6 +8,8 @@
 # - Cloud Scheduler から Job を起動
 
 resource "google_cloud_run_v2_job" "promoter" {
+  count = var.enable_promoter ? 1 : 0
+
   name                = "${var.system}-promoter-${var.environment}"
   location            = var.region
   deletion_protection = false
@@ -89,6 +91,8 @@ resource "google_cloud_run_v2_job" "promoter" {
 
 # Cloud Scheduler: 毎時間
 resource "google_cloud_scheduler_job" "promoter" {
+  count = var.enable_promoter ? 1 : 0
+
   name             = "${var.system}-promoter-${var.environment}"
   description      = "Scheduled auto post to X (every hour)"
   schedule         = var.promoter_scheduler_cron
@@ -98,7 +102,7 @@ resource "google_cloud_scheduler_job" "promoter" {
 
   http_target {
     http_method = "POST"
-    uri         = "https://run.googleapis.com/v2/projects/${var.project_id}/locations/${var.region}/jobs/${google_cloud_run_v2_job.promoter.name}:run"
+    uri         = "https://run.googleapis.com/v2/projects/${var.project_id}/locations/${var.region}/jobs/${google_cloud_run_v2_job.promoter[0].name}:run"
 
     oauth_token {
       service_account_email = local.default_compute_service_account

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -152,6 +152,18 @@ variable "sns_schedule_offset_hours" {
   default     = 1
 }
 
+variable "manage_firestore_database" {
+  type        = bool
+  description = "Whether this Terraform stack creates and manages the default Firestore database."
+  default     = false
+}
+
+variable "enable_promoter" {
+  type        = bool
+  description = "Whether to deploy the X auto-posting Cloud Run Job and Scheduler. Requires X API secrets to exist."
+  default     = false
+}
+
 variable "x_api_key_secret_name" {
   type        = string
   description = "Secret Manager secret name for X API Key (Consumer Key)."
@@ -181,4 +193,3 @@ variable "promoter_scheduler_cron" {
   description = "Execution frequency of the promoter (cron format)."
   default     = "0 * * * *"
 }
-


### PR DESCRIPTION
## 概要
CD失敗の原因になっていた未準備リソースをfeature flagで無効化します。

## 原因
- Firestore databaseをこのstackから作成しようとして403で失敗
- X API Secret未作成の状態でpromoter Cloud Run Jobを作成しようとして失敗

## 対応
- manage_firestore_databaseを追加し、既定falseに設定
- enable_promoterを追加し、既定falseに設定
- enable_promoter=trueのときだけpromoter Job / Schedulerを作成

## 確認
- terraform fmt -check -recursive
- terraform init -backend=false -input=false
- terraform validate
- git diff --check

## 補足
X投稿連携自体のコードは残し、Secret作成と運用準備が完了したタイミングでenable_promoter=trueにして有効化する想定です。