### PR TITLE
episode.py において、AudioConverter でサポートしている4種類の拡張子（.mp3, .m4a, .wav, .fl…

### DIFF
--- a/app/docs/ENVIRONMENT_AND_TEST_SPEC.md
+++ b/app/docs/ENVIRONMENT_AND_TEST_SPEC.md
@@ -22,7 +22,7 @@
 | PROJECT_ID | Yes | - | GCP project ID |
 | DATABASE_URL | Yes | - | Cloud SQL PostgreSQL connection URL |
 | GCS_BUCKET | Yes | - | Input audio bucket |
-| GCS_TRIGGER_OBJECT_NAME | Yes | - | `podcasts/{podcast_id}/episodes/{episode_id}/source/{filename}.mp3` |
+| GCS_TRIGGER_OBJECT_NAME | Yes | - | `podcasts/{podcast_id}/episodes/{episode_id}/source/{filename}.{mp3\|m4a\|wav\|flac}` |
 | R2_BUCKET | Yes | - | Cloudflare R2 bucket |
 | SECRET_NAME | Conditional | - | Secret Manager secret name |
 | CLOUDFLARE_ACCESS_KEY_ID | Conditional | - | R2 access key (when SECRET_NAME is not used) |

--- a/app/src/domain/models/episode.py
+++ b/app/src/domain/models/episode.py
@@ -6,7 +6,7 @@ import re
 from dataclasses import dataclass
 
 _EPISODE_OBJECT_PATH = re.compile(
-    r"^podcasts/(?P<podcast_id>[1-9]\d*)/episodes/(?P<episode_id>[1-9]\d*)/source/(?P<filename>[^/]+\.mp3)$",
+    r"^podcasts/(?P<podcast_id>[1-9]\d*)/episodes/(?P<episode_id>[1-9]\d*)/source/(?P<filename>[^/]+\.(?:mp3|m4a|wav|flac))$",
     re.IGNORECASE,
 )
 
@@ -25,7 +25,10 @@ class EpisodeObjectReference:
         """Parse the cross-repository GCS object path contract."""
         match = _EPISODE_OBJECT_PATH.fullmatch(object_path)
         if match is None:
-            msg = "GCS object path must match podcasts/{podcast_id}/episodes/{episode_id}/source/{filename}.mp3"
+            msg = (
+                "GCS object path must match podcasts/{podcast_id}/episodes/{episode_id}/source/"
+                "{filename}.{mp3|m4a|wav|flac}"
+            )
             raise ValueError(msg)
 
         return cls(

--- a/app/tests/test_episode_object_reference.py
+++ b/app/tests/test_episode_object_reference.py
@@ -5,12 +5,22 @@ import pytest
 from domain.models import EpisodeObjectReference
 
 
-def test_parse_episode_object_reference() -> None:
-    reference = EpisodeObjectReference.parse("podcasts/1/episodes/42/source/recording.mp3")
+@pytest.mark.parametrize(
+    ("object_path", "expected_filename"),
+    [
+        ("podcasts/1/episodes/42/source/recording.mp3", "recording.mp3"),
+        ("podcasts/1/episodes/42/source/recording.m4a", "recording.m4a"),
+        ("podcasts/1/episodes/42/source/recording.wav", "recording.wav"),
+        ("podcasts/1/episodes/42/source/recording.flac", "recording.flac"),
+        ("podcasts/1/episodes/42/source/recording.MP3", "recording.MP3"),
+    ],
+)
+def test_parse_episode_object_reference(object_path: str, expected_filename: str) -> None:
+    reference = EpisodeObjectReference.parse(object_path)
 
     assert reference.podcast_id == 1
     assert reference.episode_id == 42
-    assert reference.filename == "recording.mp3"
+    assert reference.filename == expected_filename
 
 
 @pytest.mark.parametrize(
@@ -21,7 +31,7 @@ def test_parse_episode_object_reference() -> None:
         "podcasts/1/episodes/0/source/recording.mp3",
         "podcasts/1/episodes/42/recording.mp3",
         "podcasts/1/episodes/42/source/nested/recording.mp3",
-        "podcasts/1/episodes/42/source/recording.wav",
+        "podcasts/1/episodes/42/source/recording.ogg",
     ],
 )
 def test_parse_rejects_paths_outside_contract(object_path: str) -> None:

--- a/infrastructure/environments/dev/variables.tfvars
+++ b/infrastructure/environments/dev/variables.tfvars
@@ -22,5 +22,5 @@ cloudflare_account_id              = "8ed20f6872cea7c9219d68bfcf5f98ae"
 cloudflare_zone_name               = "sunabalog.com"
 r2_bucket_name                     = "podcast-dev"
 r2_subdomain                       = "dev.podcast"
-enable_promoter                    = true
+enable_promoter                    = false
 manage_firestore_database          = false


### PR DESCRIPTION
…ac）を受け付けるように正規表現を更新

# 概要
<!-- 箇条書きで具体的に。何をどう変更したか、ロジックがどう動くのか、どのようにテストしたか、補足等 -->
-

# 関連issue
<!-- 例: Close #123 / Close #123, #456 -->
-
