### PR TITLE
Persist AI agenda conversation seeds

### DIFF
--- a/app/src/services/news_researcher.py
+++ b/app/src/services/news_researcher.py
@@ -11,6 +11,7 @@
 from __future__ import annotations
 
 import logging
+import re
 import shutil
 import subprocess
 from dataclasses import dataclass
@@ -30,6 +31,23 @@ logger = logging.getLogger(__name__)
 _DEFAULT_MODEL: str = "gemini-2.5-flash"
 _DEFAULT_LOCATION: str = "us-central1"
 _DEFAULT_MAX_ITEMS: int = 3
+_NEWS_ITEM_RE = re.compile(
+    r"^\s*\d+\.\s+\*\*(?P<title>.+?)\*\*\s+\(出典:\s*(?P<source>.+?)\)\s*$",
+)
+_CONNECTION_PREFIX = "・最近の論点との接続:"
+_INTERESTING_PREFIX = "・何が面白いか:"
+_QUESTION_PREFIX = "・次に話せそうな問い:"
+
+
+@dataclass(frozen=True)
+class AIConversationSeed:
+    """Structured conversation seed parsed from the AI news markdown."""
+
+    title: str
+    source: str
+    connection: str
+    interesting: str
+    question: str
 
 
 @dataclass(frozen=True)
@@ -157,6 +175,14 @@ class AINewsResearcher:
         else:
             logger.info("news_researcher: generated %d chars (no grounding metadata)", len(result_text))
 
+        conversation_seeds = _parse_conversation_seeds(result_text)
+        if conversation_seeds:
+            related_news = _merge_conversation_seeds_into_related_news(
+                conversation_seeds=conversation_seeds,
+                related_news=related_news,
+                max_items=max_items,
+            )
+
         return AINewsResearchResult(text=result_text, related_news=related_news)
 
 
@@ -210,6 +236,88 @@ def _build_research_prompt(
 - 1件あたり4行以内
 - 不確かな情報は「〜とのこと」等で断定を避ける
 """
+
+
+# ── Response parsing ───────────────────────────────────────────────────────────
+
+
+def _parse_conversation_seeds(text: str) -> list[AIConversationSeed]:
+    """Parse the fixed AI news markdown format into structured conversation seeds."""
+    seeds: list[AIConversationSeed] = []
+    current: dict[str, str] | None = None
+
+    def flush() -> None:
+        nonlocal current
+        if current is None:
+            return
+        required = ("title", "source", "connection", "interesting", "question")
+        if all(current.get(key) for key in required):
+            seeds.append(
+                AIConversationSeed(
+                    title=current["title"],
+                    source=current["source"],
+                    connection=current["connection"],
+                    interesting=current["interesting"],
+                    question=current["question"],
+                )
+            )
+        current = None
+
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+
+        match = _NEWS_ITEM_RE.match(line)
+        if match:
+            flush()
+            current = {
+                "title": match.group("title").strip(),
+                "source": match.group("source").strip(),
+            }
+            continue
+
+        if current is None:
+            continue
+
+        if line.startswith(_CONNECTION_PREFIX):
+            current["connection"] = line.removeprefix(_CONNECTION_PREFIX).strip()
+        elif line.startswith(_INTERESTING_PREFIX):
+            current["interesting"] = line.removeprefix(_INTERESTING_PREFIX).strip()
+        elif line.startswith(_QUESTION_PREFIX):
+            current["question"] = line.removeprefix(_QUESTION_PREFIX).strip()
+
+    flush()
+    return seeds
+
+
+def _merge_conversation_seeds_into_related_news(
+    *,
+    conversation_seeds: list[AIConversationSeed],
+    related_news: list[dict[str, str]],
+    max_items: int,
+) -> list[dict[str, str]]:
+    """Attach AI-generated discussion angles to Firestore related_news payloads."""
+    merged = [dict(item) for item in related_news[:max_items]]
+
+    for index, seed in enumerate(conversation_seeds[:max_items]):
+        if index < len(merged):
+            item = merged[index]
+        else:
+            item = {"url": ""}
+            merged.append(item)
+
+        item.update(
+            {
+                "title": seed.title,
+                "summary": seed.interesting,
+                "source": seed.source,
+                "source_reason": seed.connection,
+                "question": seed.question,
+            }
+        )
+
+    return merged[:max_items]
 
 
 # ── Auth helpers ───────────────────────────────────────────────────────────────

--- a/app/src/usecases/generate_weekly_agenda.py
+++ b/app/src/usecases/generate_weekly_agenda.py
@@ -120,6 +120,43 @@ class GenerateWeeklyAgendaUsecase:
             )
         return suggested_topics
 
+    def _build_ai_suggested_topics_payload(
+        self,
+        related_news: list[dict[str, object]] | None,
+    ) -> list[dict[str, object]]:
+        """Convert AI news research angles into editable conversation seeds."""
+        if not related_news:
+            return []
+
+        suggested_topics: list[dict[str, object]] = []
+        for item in related_news[:3]:
+            title = str(item.get("title") or "").strip()
+            connection = str(item.get("source_reason") or "").strip()
+            interesting = str(item.get("summary") or "").strip()
+            question = str(item.get("question") or "").strip()
+
+            if not title or not question:
+                continue
+
+            suggested_points: list[str] = []
+            if connection:
+                suggested_points.append(f"最近の論点との接続: {connection}")
+            if interesting:
+                suggested_points.append(f"何が面白いか: {interesting}")
+            if question:
+                suggested_points.append(f"次に話せそうな問い: {question}")
+
+            suggested_topics.append(
+                {
+                    "title": title,
+                    "description": question or interesting or connection,
+                    "suggested_points": suggested_points,
+                    "related_past_episodes": [],
+                },
+            )
+
+        return suggested_topics
+
     def _save_topic_proposal(
         self,
         *,
@@ -135,6 +172,9 @@ class GenerateWeeklyAgendaUsecase:
         news_payload = related_news
         if news_payload is None:
             news_payload = self._build_related_news_payload(news_candidates)  # type: ignore[assignment]
+        suggested_topics = self._build_ai_suggested_topics_payload(news_payload)
+        if not suggested_topics:
+            suggested_topics = self._build_suggested_topics_payload(result)
 
         return self._firestore_manager.create_topic_proposal(
             podcast_id=podcast_id,
@@ -142,5 +182,5 @@ class GenerateWeeklyAgendaUsecase:
             target_period_string=self._build_target_period_string(result.metadata.generated_at),
             generated_at=result.metadata.generated_at,
             related_news=news_payload[:3],
-            suggested_topics=self._build_suggested_topics_payload(result),
+            suggested_topics=suggested_topics,
         )

--- a/app/tests/test_generate_weekly_agenda.py
+++ b/app/tests/test_generate_weekly_agenda.py
@@ -122,6 +122,65 @@ def test_generate_weekly_agenda_saves_to_firestore() -> None:
     assert kwargs["suggested_topics"][0]["related_past_episodes"] == [1]
 
 
+def test_generate_weekly_agenda_saves_ai_news_angles_as_suggested_topics() -> None:
+    # Arrange
+    notifier = mock.Mock(spec=NotificationGateway)
+    notifier.send_discord_message.return_value = True
+    firestore_manager = mock.Mock(spec=FirestoreManager)
+    firestore_manager.create_topic_proposal.return_value = "proposal-123"
+    logger = logging.getLogger("test_agenda")
+
+    usecase = GenerateWeeklyAgendaUsecase(
+        notifier=notifier,
+        firestore_manager=firestore_manager,
+        logger=logger,
+    )
+
+    theme1 = FakeTopicMatch(
+        topic_id="tech-ai",
+        display_name="AI Theme",
+        mention_count=2,
+        evidence=[FakeEvidence(source_episode=1, text="Raw transcript fragment")],
+    )
+    result = FakeAgendaResult(
+        generated_at="2026-06-25T00:00:00Z",
+        recurring_themes=[theme1],
+    )
+    related_news = [
+        {
+            "title": "AIモデルの運用停止リスク",
+            "url": "https://example.com/news",
+            "summary": "技術選定だけではなく、供給リスクがプロダクト設計に直結する点。",
+            "source_reason": "LLMへの依存を話していたが、外部要因で突然止まる観点が加わる。",
+            "question": "AI基盤を複数持つ設計はどこまで現実的か?",
+        }
+    ]
+
+    # Act
+    success = usecase.run(
+        message_builder=lambda: ("Agenda Message", result, [], related_news),
+        fallback_message="Fallback",
+        podcast_id="podcast-456",
+    )
+
+    # Assert
+    assert success is True
+    _, kwargs = firestore_manager.create_topic_proposal.call_args
+    assert kwargs["related_news"] == related_news
+    assert kwargs["suggested_topics"] == [
+        {
+            "title": "AIモデルの運用停止リスク",
+            "description": "AI基盤を複数持つ設計はどこまで現実的か?",
+            "suggested_points": [
+                "最近の論点との接続: LLMへの依存を話していたが、外部要因で突然止まる観点が加わる。",
+                "何が面白いか: 技術選定だけではなく、供給リスクがプロダクト設計に直結する点。",
+                "次に話せそうな問い: AI基盤を複数持つ設計はどこまで現実的か?",
+            ],
+            "related_past_episodes": [],
+        }
+    ]
+
+
 def test_generate_weekly_agenda_builder_failure_falls_back() -> None:
     # Arrange
     notifier = mock.Mock(spec=NotificationGateway)

--- a/app/tests/test_news_researcher.py
+++ b/app/tests/test_news_researcher.py
@@ -8,7 +8,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 from google.auth.exceptions import DefaultCredentialsError
 
-from services.news_researcher import AINewsResearcher, _build_research_prompt, _resolve_credentials
+from services.news_researcher import (
+    AINewsResearcher,
+    _build_research_prompt,
+    _parse_conversation_seeds,
+    _resolve_credentials,
+)
 from services.transcript_analyzer import MentionEvidence, TopicMatch
 
 # ── Fixtures / Helpers ─────────────────────────────────────────────────────────
@@ -52,6 +57,16 @@ def _make_mock_response_with_grounding(text: str = "Generated news content") -> 
     candidate.grounding_metadata = meta
     response.candidates = [candidate]
     return response
+
+
+def _make_ai_news_text() -> str:
+    return """1. **AIモデルの運用停止リスク** (出典: Example News)
+・最近の論点との接続: LLMへの依存を話していたが、外部要因で突然止まる観点が加わる。
+・何が面白いか: 技術選定だけではなく、供給リスクがプロダクト設計に直結する点。
+・次に話せそうな問い: AI基盤を複数持つ設計はどこまで現実的か?
+
+💬 今週の切り口: AIを前提にした開発体制の脆さから話す。
+"""
 
 
 # ── TestBuildResearchPrompt ────────────────────────────────────────────────────
@@ -218,6 +233,40 @@ class TestAINewsResearcher:
                 "url": "https://example.com/article",
                 "summary": "",
                 "source_reason": "Gemini Google Search grounding",
+            }
+        ]
+
+    def test_parse_conversation_seeds_from_ai_news_text(self):
+        """AI本文から会話の種の3項目を構造化できること."""
+        result = _parse_conversation_seeds(_make_ai_news_text())
+
+        assert len(result) == 1
+        assert result[0].title == "AIモデルの運用停止リスク"
+        assert result[0].source == "Example News"
+        assert result[0].connection == "LLMへの依存を話していたが、外部要因で突然止まる観点が加わる。"
+        assert result[0].interesting == "技術選定だけではなく、供給リスクがプロダクト設計に直結する点。"
+        assert result[0].question == "AI基盤を複数持つ設計はどこまで現実的か?"
+
+    @patch("services.news_researcher._resolve_credentials", return_value=None)
+    @patch("services.news_researcher.genai.Client")
+    def test_research_with_sources_merges_ai_angles_into_related_news(self, mock_client_cls, mock_creds):
+        """AI本文の3項目をFirestore保存用related_newsへ反映すること."""
+        _ = mock_creds
+        mock_client_cls.return_value.models.generate_content.return_value = _make_mock_response_with_grounding(
+            _make_ai_news_text()
+        )
+        researcher = AINewsResearcher(project_id="test-project")
+
+        result = researcher.research_with_sources([_make_topic()])
+
+        assert result.related_news == [
+            {
+                "title": "AIモデルの運用停止リスク",
+                "url": "https://example.com/article",
+                "summary": "技術選定だけではなく、供給リスクがプロダクト設計に直結する点。",
+                "source": "Example News",
+                "source_reason": "LLMへの依存を話していたが、外部要因で突然止まる観点が加わる。",
+                "question": "AI基盤を複数持つ設計はどこまで現実的か?",
             }
         ]
 


### PR DESCRIPTION
## Summary
- Parse the AI agenda news markdown into structured conversation seed fields
- Persist connection / interesting point / next question into Firestore-friendly related_news
- Prefer those AI-generated angles for topic_proposals.suggested_topics when available

## Verification
- uv run ruff check .
- uv run pytest