### PR TITLE
Promote agenda Firestore source to production

### DIFF
--- a/app/docs/ENVIRONMENT_AND_TEST_SPEC.md
+++ b/app/docs/ENVIRONMENT_AND_TEST_SPEC.md
@@ -44,15 +44,22 @@ Conditional rule:
 | Name | Required | Default | Description |
 | --- | --- | --- | --- |
 | DISCORD_WEBHOOK_AGENDA_URL | Yes | - | Weekly agenda post destination |
-| DISCORD_BOT_TOKEN | No | - | Discord API token for transcript fetching |
-| DISCORD_TRANSCRIPT_CHANNEL_ID | No | - | Source channel ID for transcript messages |
-| TRANSCRIPT_FETCH_LIMIT | No | 50 | Number of messages to fetch |
+| PROJECT_ID | Yes when Firestore persistence/source is enabled | - | GCP project ID for Firestore |
+| PODCAST_ID | Yes when Firestore persistence/source is enabled | - | Firestore podcast document ID |
+| DISCORD_BOT_TOKEN | No | - | Discord API token for fallback transcript fetching |
+| DISCORD_TRANSCRIPT_CHANNEL_ID | No | - | Fallback source channel ID for transcript messages |
+| TRANSCRIPT_FETCH_LIMIT | No | 50 | Number of Firestore episodes or Discord messages to fetch |
 | DEBUG_JSON_PATH | No | - | Optional path to dump AgendaResult JSON |
 | GOOGLE_CLOUD_PROJECT | No | - | Required only when AI news research is enabled |
 
 Behavior rule:
 
-- DISCORD_BOT_TOKEN または DISCORD_TRANSCRIPT_CHANNEL_ID が未設定の場合、transcript 解析をスキップして固定メッセージで通知します。
+- Agenda job first reads stored transcripts from Firestore:
+  `podcasts/{podcast_id}/episodes_contents/{episode_id}/transcripts/{chunk_id}`.
+- If Firestore has no transcript episodes, it falls back to Discord transcript
+  fetching.
+- If neither Firestore transcripts nor Discord credentials are available, it
+  sends the fixed reminder message.
 
 ## 3. Secret Manager Contract
 

--- a/app/docs/FIRESTORE_SPEC.md
+++ b/app/docs/FIRESTORE_SPEC.md
@@ -20,7 +20,8 @@ flowchart TD
 
     subgraph "2. アジェンダ生成ジョブ (agenda)"
         Schedule["Cloud Scheduler<br>(毎週水曜 07:00 JST)"] -->|起動| AgendaJob["Cloud Run Job: agenda<br>(entrypoints/agenda_main.py)"]
-        Discord["Discord Transcript Channel"] -->|過去の会話取得| AgendaJob
+        DocTrans -->|過去議事録取得| AgendaJob
+        Discord["Discord Transcript Channel"] -.->|Firestoreに議事録が無い場合のみfallback| AgendaJob
         RSS["RSS ニュースフィード"] -->|ニュース取得| AgendaJob
         AgendaJob -->|関連度マッチング & AI検索| AgendaJob
         AgendaJob -->|書き込み| DocProposal["topic_proposals<br>(議題提案)"]
@@ -187,6 +188,7 @@ flowchart TD
 
 - **Firestore パス**: `podcasts/{podcast_id}/topic_proposals/{proposal_id}`
 - **生成ジョブ**: `podcast-automator-agenda-{environment}` (`app/src/entrypoints/agenda_main.py`)
+- **入力元**: 原則として Firestore の `episodes_contents/{episode_id}/transcripts/{chunk_id}` を使用する。Firestoreに議事録が存在しない場合のみ、後方互換のfallbackとしてDiscord Transcript Channelを参照する。
 - **ドキュメントID (`{proposal_id}`)**: 新規生成された UUID (32文字の hex 文字列)
 
 #### スキーマ定義

--- a/app/src/entrypoints/agenda_main.py
+++ b/app/src/entrypoints/agenda_main.py
@@ -18,7 +18,7 @@ from services.firestore_manager import FirestoreManager
 from services.news_fetcher import DEFAULT_RSS_SOURCES, NewsFetcher
 from services.news_relevance import match_news_to_agenda
 from services.news_researcher import AINewsResearcher
-from services.transcript_analyzer import AgendaResult, TranscriptAnalyzer
+from services.transcript_analyzer import AgendaResult, Episode, TranscriptAnalyzer
 from usecases import GenerateWeeklyAgendaUsecase
 
 if TYPE_CHECKING:
@@ -63,10 +63,83 @@ def _load_agenda_env() -> AgendaEnvConfig:
     )
 
 
-# (relocated Firestore saving helper methods to GenerateWeeklyAgendaUsecase)
+def _build_agenda_from_episodes(
+    *,
+    episodes: list[Episode],
+    analysis_window_size: int,
+    fetched_message_count: int,
+) -> tuple[AgendaResult, list[NewsCandidate]]:
+    """Analyze reconstructed episodes and match RSS news."""
+    analyzer = TranscriptAnalyzer()
+    recurring_themes = analyzer.extract_recurring_themes(episodes)
+    action_items = analyzer.extract_action_items(episodes)
+    discussion_prompts = analyzer.extract_discussion_prompts(episodes)
+    logger.info(
+        "Extracted: themes=%d, action_items=%d, prompts=%d.",
+        len(recurring_themes),
+        len(action_items),
+        len(discussion_prompts),
+    )
+
+    result = analyzer.build_agenda(
+        episodes=episodes,
+        recurring_themes=recurring_themes,
+        action_items=action_items,
+        discussion_prompts=discussion_prompts,
+        generated_at=datetime.now(UTC).isoformat(),
+        analysis_window_size=analysis_window_size,
+        fetched_message_count=fetched_message_count,
+    )
+
+    news_candidates: list[NewsCandidate] = []
+    try:
+        news_items = NewsFetcher().fetch_all(DEFAULT_RSS_SOURCES)
+        logger.info("Fetched %d news items from RSS.", len(news_items))
+        news_candidates = match_news_to_agenda(news_items, result)
+        logger.info("Matched %d news candidates.", len(news_candidates))
+    except Exception:  # noqa: BLE001
+        logger.warning("News fetch/match failed. Continuing without news.", exc_info=True)
+
+    return result, news_candidates
 
 
-def _fetch_and_reconstruct(cfg: AgendaEnvConfig) -> tuple[AgendaResult | None, list[str], list[NewsCandidate]]:
+def _fetch_from_firestore(
+    *,
+    cfg: AgendaEnvConfig,
+    firestore_manager: FirestoreManager | None,
+) -> tuple[AgendaResult | None, list[str], list[NewsCandidate]]:
+    """Fetch stored transcripts from Firestore and build an agenda."""
+    if firestore_manager is None or not cfg.podcast_id:
+        logger.info("FirestoreManager / PODCAST_ID が未設定のため Firestore transcript 取得をスキップします。")
+        return None, [], []
+
+    raw_episodes = firestore_manager.list_recent_transcript_episodes(
+        podcast_id=cfg.podcast_id,
+        limit=cfg.transcript_fetch_limit,
+    )
+    if not raw_episodes:
+        logger.info("Firestore に agenda 生成対象の transcripts がありません。")
+        return None, [], []
+
+    episodes = [
+        Episode(
+            number=int(item["episode_number"]),
+            content=str(item["content"]),
+            timestamp=str(item.get("updated_at") or ""),
+            source_message_ids=[str(item["episode_id"])],
+        )
+        for item in raw_episodes
+    ]
+    logger.info("Fetched %d transcript episodes from Firestore.", len(episodes))
+    result, news_candidates = _build_agenda_from_episodes(
+        episodes=episodes,
+        analysis_window_size=cfg.transcript_fetch_limit,
+        fetched_message_count=len(episodes),
+    )
+    return result, [], news_candidates
+
+
+def _fetch_from_discord(cfg: AgendaEnvConfig) -> tuple[AgendaResult | None, list[str], list[NewsCandidate]]:
     """Fetch Discord transcripts, reconstruct episodes, and match RSS news."""
     if not cfg.discord_bot_token or not cfg.discord_transcript_channel_id:
         logger.info(
@@ -91,36 +164,28 @@ def _fetch_and_reconstruct(cfg: AgendaEnvConfig) -> tuple[AgendaResult | None, l
     for warning in warnings:
         logger.warning("  [transcript] %s", warning)
 
-    recurring_themes = analyzer.extract_recurring_themes(episodes)
-    action_items = analyzer.extract_action_items(episodes)
-    discussion_prompts = analyzer.extract_discussion_prompts(episodes)
-    logger.info(
-        "Extracted: themes=%d, action_items=%d, prompts=%d.",
-        len(recurring_themes),
-        len(action_items),
-        len(discussion_prompts),
-    )
-
-    result = analyzer.build_agenda(
+    result, news_candidates = _build_agenda_from_episodes(
         episodes=episodes,
-        recurring_themes=recurring_themes,
-        action_items=action_items,
-        discussion_prompts=discussion_prompts,
-        generated_at=datetime.now(UTC).isoformat(),
         analysis_window_size=cfg.transcript_fetch_limit,
         fetched_message_count=len(messages),
     )
-
-    news_candidates: list[NewsCandidate] = []
-    try:
-        news_items = NewsFetcher().fetch_all(DEFAULT_RSS_SOURCES)
-        logger.info("Fetched %d news items from RSS.", len(news_items))
-        news_candidates = match_news_to_agenda(news_items, result)
-        logger.info("Matched %d news candidates.", len(news_candidates))
-    except Exception:  # noqa: BLE001
-        logger.warning("News fetch/match failed. Continuing without news.", exc_info=True)
-
     return result, warnings, news_candidates
+
+
+def _fetch_and_reconstruct(
+    cfg: AgendaEnvConfig,
+    firestore_manager: FirestoreManager | None,
+) -> tuple[AgendaResult | None, list[str], list[NewsCandidate]]:
+    """Fetch transcripts from Firestore first, falling back to Discord."""
+    firestore_result, firestore_warnings, firestore_news = _fetch_from_firestore(
+        cfg=cfg,
+        firestore_manager=firestore_manager,
+    )
+    if firestore_result is not None:
+        return firestore_result, firestore_warnings, firestore_news
+
+    logger.info("Falling back to Discord transcript source.")
+    return _fetch_from_discord(cfg)
 
 
 def _export_debug_json(result: AgendaResult, path: str) -> None:
@@ -151,7 +216,7 @@ def send_weekly_agenda() -> None:
     )
 
     def build_agenda_message() -> tuple[str, AgendaResult | None, list[NewsCandidate], list[dict[str, object]] | None]:
-        result, _warnings, news_candidates = _fetch_and_reconstruct(cfg)
+        result, _warnings, news_candidates = _fetch_and_reconstruct(cfg, firestore_manager)
         if result is None:
             return AGENDA_MESSAGE, None, [], None
 

--- a/app/src/services/firestore_manager.py
+++ b/app/src/services/firestore_manager.py
@@ -148,6 +148,52 @@ class FirestoreManager:
         )
         return doc_ref.id
 
+    def list_recent_transcript_episodes(
+        self,
+        *,
+        podcast_id: str,
+        limit: int,
+    ) -> list[dict[str, Any]]:
+        """Read recent episode transcripts from Firestore for agenda generation."""
+        query = (
+            self._episode_contents_collection(podcast_id)
+            .order_by("updated_at", direction=firestore.Query.DESCENDING)
+            .limit(limit)
+        )
+        episodes: list[dict[str, Any]] = []
+
+        for doc in query.stream():
+            data = doc.to_dict() or {}
+            episode_number = data.get("episode_number")
+            if not isinstance(episode_number, int):
+                continue
+
+            transcript_parts: list[str] = []
+            transcript_docs = doc.reference.collection("transcripts").order_by("chunk_id").stream()
+            for transcript_doc in transcript_docs:
+                transcript_data = transcript_doc.to_dict() or {}
+                text = transcript_data.get("text")
+                if isinstance(text, str) and text.strip():
+                    transcript_parts.append(text.strip())
+
+            content = "\n\n".join(transcript_parts).strip()
+            if not content:
+                summary = data.get("transcript_summary")
+                content = summary.strip() if isinstance(summary, str) else ""
+            if not content:
+                continue
+
+            episodes.append(
+                {
+                    "episode_id": doc.id,
+                    "episode_number": episode_number,
+                    "content": content,
+                    "updated_at": str(data.get("updated_at") or ""),
+                },
+            )
+
+        return sorted(episodes, key=lambda item: int(item["episode_number"]))
+
     def get_pending_sns_promotions(self) -> list[dict[str, Any]]:
         """Retrieve all pending SNS promotions across all episodes using a collection group query."""
         query = self._client.collection_group("sns_promotions").where("status", "==", "pending")

--- a/app/src/services/news_researcher.py
+++ b/app/src/services/news_researcher.py
@@ -11,6 +11,7 @@
 from __future__ import annotations
 
 import logging
+import re
 import shutil
 import subprocess
 from dataclasses import dataclass
@@ -30,6 +31,23 @@ logger = logging.getLogger(__name__)
 _DEFAULT_MODEL: str = "gemini-2.5-flash"
 _DEFAULT_LOCATION: str = "us-central1"
 _DEFAULT_MAX_ITEMS: int = 3
+_NEWS_ITEM_RE = re.compile(
+    r"^\s*\d+\.\s+\*\*(?P<title>.+?)\*\*\s+\(出典:\s*(?P<source>.+?)\)\s*$",
+)
+_CONNECTION_PREFIX = "・最近の論点との接続:"
+_INTERESTING_PREFIX = "・何が面白いか:"
+_QUESTION_PREFIX = "・次に話せそうな問い:"
+
+
+@dataclass(frozen=True)
+class AIConversationSeed:
+    """Structured conversation seed parsed from the AI news markdown."""
+
+    title: str
+    source: str
+    connection: str
+    interesting: str
+    question: str
 
 
 @dataclass(frozen=True)
@@ -157,6 +175,14 @@ class AINewsResearcher:
         else:
             logger.info("news_researcher: generated %d chars (no grounding metadata)", len(result_text))
 
+        conversation_seeds = _parse_conversation_seeds(result_text)
+        if conversation_seeds:
+            related_news = _merge_conversation_seeds_into_related_news(
+                conversation_seeds=conversation_seeds,
+                related_news=related_news,
+                max_items=max_items,
+            )
+
         return AINewsResearchResult(text=result_text, related_news=related_news)
 
 
@@ -210,6 +236,88 @@ def _build_research_prompt(
 - 1件あたり4行以内
 - 不確かな情報は「〜とのこと」等で断定を避ける
 """
+
+
+# ── Response parsing ───────────────────────────────────────────────────────────
+
+
+def _parse_conversation_seeds(text: str) -> list[AIConversationSeed]:
+    """Parse the fixed AI news markdown format into structured conversation seeds."""
+    seeds: list[AIConversationSeed] = []
+    current: dict[str, str] | None = None
+
+    def flush() -> None:
+        nonlocal current
+        if current is None:
+            return
+        required = ("title", "source", "connection", "interesting", "question")
+        if all(current.get(key) for key in required):
+            seeds.append(
+                AIConversationSeed(
+                    title=current["title"],
+                    source=current["source"],
+                    connection=current["connection"],
+                    interesting=current["interesting"],
+                    question=current["question"],
+                )
+            )
+        current = None
+
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+
+        match = _NEWS_ITEM_RE.match(line)
+        if match:
+            flush()
+            current = {
+                "title": match.group("title").strip(),
+                "source": match.group("source").strip(),
+            }
+            continue
+
+        if current is None:
+            continue
+
+        if line.startswith(_CONNECTION_PREFIX):
+            current["connection"] = line.removeprefix(_CONNECTION_PREFIX).strip()
+        elif line.startswith(_INTERESTING_PREFIX):
+            current["interesting"] = line.removeprefix(_INTERESTING_PREFIX).strip()
+        elif line.startswith(_QUESTION_PREFIX):
+            current["question"] = line.removeprefix(_QUESTION_PREFIX).strip()
+
+    flush()
+    return seeds
+
+
+def _merge_conversation_seeds_into_related_news(
+    *,
+    conversation_seeds: list[AIConversationSeed],
+    related_news: list[dict[str, str]],
+    max_items: int,
+) -> list[dict[str, str]]:
+    """Attach AI-generated discussion angles to Firestore related_news payloads."""
+    merged = [dict(item) for item in related_news[:max_items]]
+
+    for index, seed in enumerate(conversation_seeds[:max_items]):
+        if index < len(merged):
+            item = merged[index]
+        else:
+            item = {"url": ""}
+            merged.append(item)
+
+        item.update(
+            {
+                "title": seed.title,
+                "summary": seed.interesting,
+                "source": seed.source,
+                "source_reason": seed.connection,
+                "question": seed.question,
+            }
+        )
+
+    return merged[:max_items]
 
 
 # ── Auth helpers ───────────────────────────────────────────────────────────────

--- a/app/src/usecases/generate_weekly_agenda.py
+++ b/app/src/usecases/generate_weekly_agenda.py
@@ -120,6 +120,43 @@ class GenerateWeeklyAgendaUsecase:
             )
         return suggested_topics
 
+    def _build_ai_suggested_topics_payload(
+        self,
+        related_news: list[dict[str, object]] | None,
+    ) -> list[dict[str, object]]:
+        """Convert AI news research angles into editable conversation seeds."""
+        if not related_news:
+            return []
+
+        suggested_topics: list[dict[str, object]] = []
+        for item in related_news[:3]:
+            title = str(item.get("title") or "").strip()
+            connection = str(item.get("source_reason") or "").strip()
+            interesting = str(item.get("summary") or "").strip()
+            question = str(item.get("question") or "").strip()
+
+            if not title or not question:
+                continue
+
+            suggested_points: list[str] = []
+            if connection:
+                suggested_points.append(f"最近の論点との接続: {connection}")
+            if interesting:
+                suggested_points.append(f"何が面白いか: {interesting}")
+            if question:
+                suggested_points.append(f"次に話せそうな問い: {question}")
+
+            suggested_topics.append(
+                {
+                    "title": title,
+                    "description": question or interesting or connection,
+                    "suggested_points": suggested_points,
+                    "related_past_episodes": [],
+                },
+            )
+
+        return suggested_topics
+
     def _save_topic_proposal(
         self,
         *,
@@ -135,6 +172,9 @@ class GenerateWeeklyAgendaUsecase:
         news_payload = related_news
         if news_payload is None:
             news_payload = self._build_related_news_payload(news_candidates)  # type: ignore[assignment]
+        suggested_topics = self._build_ai_suggested_topics_payload(news_payload)
+        if not suggested_topics:
+            suggested_topics = self._build_suggested_topics_payload(result)
 
         return self._firestore_manager.create_topic_proposal(
             podcast_id=podcast_id,
@@ -142,5 +182,5 @@ class GenerateWeeklyAgendaUsecase:
             target_period_string=self._build_target_period_string(result.metadata.generated_at),
             generated_at=result.metadata.generated_at,
             related_news=news_payload[:3],
-            suggested_topics=self._build_suggested_topics_payload(result),
+            suggested_topics=suggested_topics,
         )

--- a/app/tests/test_entrypoint_config.py
+++ b/app/tests/test_entrypoint_config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+from entrypoints.agenda_main import AgendaEnvConfig, _fetch_and_reconstruct
 from entrypoints.main import _load_podcast_env
 
 
@@ -29,3 +30,44 @@ def test_load_podcast_env_does_not_require_fixed_podcast_id() -> None:
     config = _load_podcast_env(_base_env())
 
     assert config.database_url.startswith("postgresql://")
+
+
+class _FakeFirestoreManager:
+    def list_recent_transcript_episodes(self, *, podcast_id: str, limit: int) -> list[dict[str, object]]:
+        assert podcast_id == "1"
+        assert limit == 5
+        return [
+            {
+                "episode_id": "episode-42",
+                "episode_number": 42,
+                "content": "AI / LLM を活用したポッドキャスト収録フローを自動化する。どう設計すべきか?",
+                "updated_at": "2026-06-30T00:00:00Z",
+            }
+        ]
+
+
+def test_agenda_fetch_prefers_firestore_transcripts(monkeypatch: pytest.MonkeyPatch) -> None:
+    cfg = AgendaEnvConfig(
+        project_id="project",
+        podcast_id="1",
+        discord_webhook_agenda_url="https://example.com/webhook",
+        discord_bot_token=None,
+        discord_transcript_channel_id=None,
+        transcript_fetch_limit=5,
+        debug_json_path=None,
+        gcp_project_id=None,
+    )
+
+    class EmptyNewsFetcher:
+        def fetch_all(self, _sources: object) -> list[object]:
+            return []
+
+    monkeypatch.setattr("entrypoints.agenda_main.NewsFetcher", EmptyNewsFetcher)
+
+    result, warnings, news_candidates = _fetch_and_reconstruct(cfg, _FakeFirestoreManager())  # type: ignore[arg-type]
+
+    assert warnings == []
+    assert news_candidates == []
+    assert result is not None
+    assert result.analyzed_episodes == 1
+    assert result.metadata.source_episode_numbers == [42]

--- a/app/tests/test_firestore_manager.py
+++ b/app/tests/test_firestore_manager.py
@@ -19,9 +19,17 @@ class _FakeDocRef:
 
     def set(self, data: dict[str, object], merge: bool = False) -> None:  # noqa: FBT001, FBT002
         self.set_calls.append((data, merge))
+        self.data = data
 
     def collection(self, name: str) -> _FakeCollectionRef:
         return self._collections.setdefault(name, _FakeCollectionRef(f"{self.path}/{name}"))
+
+    def to_dict(self) -> dict[str, object]:
+        return getattr(self, "data", {})
+
+    @property
+    def reference(self) -> _FakeDocRef:
+        return self
 
 
 @dataclass
@@ -33,6 +41,17 @@ class _FakeCollectionRef:
 
     def document(self, doc_id: str) -> _FakeDocRef:
         return self.documents.setdefault(doc_id, _FakeDocRef(f"{self.path}/{doc_id}"))
+
+    def order_by(self, *_args: object, **_kwargs: object) -> _FakeCollectionRef:
+        return self
+
+    def limit(self, count: int) -> _FakeCollectionRef:
+        self._limit = count
+        return self
+
+    def stream(self) -> list[_FakeDocRef]:
+        docs = list(self.documents.values())
+        return docs[: getattr(self, "_limit", len(docs))]
 
 
 class _FakeBatch:
@@ -158,3 +177,30 @@ def test_create_topic_proposal_writes_top_level_document() -> None:
     assert proposal_id == "proposal-1"
     doc_ref = client.collection("podcasts").document("podcast-1").collection("topic_proposals").document("proposal-1")
     assert doc_ref.set_calls[0][0]["target_period_string"] == "2026年 第23週 (06/01 - 06/07)"
+
+
+def test_list_recent_transcript_episodes_reads_transcript_chunks() -> None:
+    client = _FakeClient()
+    manager = FirestoreManager(project_id="demo", client=client)
+    episode_doc = client.collection("podcasts").document("podcast-1").collection("episodes_contents").document("ep-1")
+    episode_doc.set(
+        {
+            "episode_number": 42,
+            "updated_at": "2026-06-30T00:00:00Z",
+            "transcript_summary": "summary",
+        },
+        merge=True,
+    )
+    episode_doc.collection("transcripts").document("chunk_0001").set({"text": "part 1"}, merge=False)
+    episode_doc.collection("transcripts").document("chunk_0002").set({"text": "part 2"}, merge=False)
+
+    result = manager.list_recent_transcript_episodes(podcast_id="podcast-1", limit=10)
+
+    assert result == [
+        {
+            "episode_id": "ep-1",
+            "episode_number": 42,
+            "content": "part 1\n\npart 2",
+            "updated_at": "2026-06-30T00:00:00Z",
+        }
+    ]

--- a/app/tests/test_generate_weekly_agenda.py
+++ b/app/tests/test_generate_weekly_agenda.py
@@ -122,6 +122,65 @@ def test_generate_weekly_agenda_saves_to_firestore() -> None:
     assert kwargs["suggested_topics"][0]["related_past_episodes"] == [1]
 
 
+def test_generate_weekly_agenda_saves_ai_news_angles_as_suggested_topics() -> None:
+    # Arrange
+    notifier = mock.Mock(spec=NotificationGateway)
+    notifier.send_discord_message.return_value = True
+    firestore_manager = mock.Mock(spec=FirestoreManager)
+    firestore_manager.create_topic_proposal.return_value = "proposal-123"
+    logger = logging.getLogger("test_agenda")
+
+    usecase = GenerateWeeklyAgendaUsecase(
+        notifier=notifier,
+        firestore_manager=firestore_manager,
+        logger=logger,
+    )
+
+    theme1 = FakeTopicMatch(
+        topic_id="tech-ai",
+        display_name="AI Theme",
+        mention_count=2,
+        evidence=[FakeEvidence(source_episode=1, text="Raw transcript fragment")],
+    )
+    result = FakeAgendaResult(
+        generated_at="2026-06-25T00:00:00Z",
+        recurring_themes=[theme1],
+    )
+    related_news = [
+        {
+            "title": "AIモデルの運用停止リスク",
+            "url": "https://example.com/news",
+            "summary": "技術選定だけではなく、供給リスクがプロダクト設計に直結する点。",
+            "source_reason": "LLMへの依存を話していたが、外部要因で突然止まる観点が加わる。",
+            "question": "AI基盤を複数持つ設計はどこまで現実的か?",
+        }
+    ]
+
+    # Act
+    success = usecase.run(
+        message_builder=lambda: ("Agenda Message", result, [], related_news),
+        fallback_message="Fallback",
+        podcast_id="podcast-456",
+    )
+
+    # Assert
+    assert success is True
+    _, kwargs = firestore_manager.create_topic_proposal.call_args
+    assert kwargs["related_news"] == related_news
+    assert kwargs["suggested_topics"] == [
+        {
+            "title": "AIモデルの運用停止リスク",
+            "description": "AI基盤を複数持つ設計はどこまで現実的か?",
+            "suggested_points": [
+                "最近の論点との接続: LLMへの依存を話していたが、外部要因で突然止まる観点が加わる。",
+                "何が面白いか: 技術選定だけではなく、供給リスクがプロダクト設計に直結する点。",
+                "次に話せそうな問い: AI基盤を複数持つ設計はどこまで現実的か?",
+            ],
+            "related_past_episodes": [],
+        }
+    ]
+
+
 def test_generate_weekly_agenda_builder_failure_falls_back() -> None:
     # Arrange
     notifier = mock.Mock(spec=NotificationGateway)

--- a/app/tests/test_news_researcher.py
+++ b/app/tests/test_news_researcher.py
@@ -8,7 +8,12 @@ from unittest.mock import MagicMock, patch
 import pytest
 from google.auth.exceptions import DefaultCredentialsError
 
-from services.news_researcher import AINewsResearcher, _build_research_prompt, _resolve_credentials
+from services.news_researcher import (
+    AINewsResearcher,
+    _build_research_prompt,
+    _parse_conversation_seeds,
+    _resolve_credentials,
+)
 from services.transcript_analyzer import MentionEvidence, TopicMatch
 
 # ── Fixtures / Helpers ─────────────────────────────────────────────────────────
@@ -52,6 +57,16 @@ def _make_mock_response_with_grounding(text: str = "Generated news content") -> 
     candidate.grounding_metadata = meta
     response.candidates = [candidate]
     return response
+
+
+def _make_ai_news_text() -> str:
+    return """1. **AIモデルの運用停止リスク** (出典: Example News)
+・最近の論点との接続: LLMへの依存を話していたが、外部要因で突然止まる観点が加わる。
+・何が面白いか: 技術選定だけではなく、供給リスクがプロダクト設計に直結する点。
+・次に話せそうな問い: AI基盤を複数持つ設計はどこまで現実的か?
+
+💬 今週の切り口: AIを前提にした開発体制の脆さから話す。
+"""
 
 
 # ── TestBuildResearchPrompt ────────────────────────────────────────────────────
@@ -218,6 +233,40 @@ class TestAINewsResearcher:
                 "url": "https://example.com/article",
                 "summary": "",
                 "source_reason": "Gemini Google Search grounding",
+            }
+        ]
+
+    def test_parse_conversation_seeds_from_ai_news_text(self):
+        """AI本文から会話の種の3項目を構造化できること."""
+        result = _parse_conversation_seeds(_make_ai_news_text())
+
+        assert len(result) == 1
+        assert result[0].title == "AIモデルの運用停止リスク"
+        assert result[0].source == "Example News"
+        assert result[0].connection == "LLMへの依存を話していたが、外部要因で突然止まる観点が加わる。"
+        assert result[0].interesting == "技術選定だけではなく、供給リスクがプロダクト設計に直結する点。"
+        assert result[0].question == "AI基盤を複数持つ設計はどこまで現実的か?"
+
+    @patch("services.news_researcher._resolve_credentials", return_value=None)
+    @patch("services.news_researcher.genai.Client")
+    def test_research_with_sources_merges_ai_angles_into_related_news(self, mock_client_cls, mock_creds):
+        """AI本文の3項目をFirestore保存用related_newsへ反映すること."""
+        _ = mock_creds
+        mock_client_cls.return_value.models.generate_content.return_value = _make_mock_response_with_grounding(
+            _make_ai_news_text()
+        )
+        researcher = AINewsResearcher(project_id="test-project")
+
+        result = researcher.research_with_sources([_make_topic()])
+
+        assert result.related_news == [
+            {
+                "title": "AIモデルの運用停止リスク",
+                "url": "https://example.com/article",
+                "summary": "技術選定だけではなく、供給リスクがプロダクト設計に直結する点。",
+                "source": "Example News",
+                "source_reason": "LLMへの依存を話していたが、外部要因で突然止まる観点が加わる。",
+                "question": "AI基盤を複数持つ設計はどこまで現実的か?",
             }
         ]
 


### PR DESCRIPTION
## Summary
- persist AI-generated agenda conversation seed details to Firestore
- use Firestore episode transcripts as the primary agenda input source
- keep Discord transcript fetching only as a fallback
- update agenda/firestore docs and tests

## Verification
- uv run ruff check .
- uv run pytest
- dev CD succeeded
- manual dev agenda job succeeded: podcast-automator-agenda-dev-zmnlr
